### PR TITLE
support output raw content for CommadWidget

### DIFF
--- a/src/widgets/command.rs
+++ b/src/widgets/command.rs
@@ -93,8 +93,12 @@ impl Widget for CommandWidget {
                     .unwrap_or(&command_result.stderr),
             );
         }
-
-        command_config.format.format_string(&content)
+        if command_config.format != FormattedPart::default() {
+            command_config.format.format_string(&content)
+        }
+        else{
+            return content;
+        }
     }
 
     fn process_click(&self, _state: &ZellijState, _pos: usize) {}


### PR DESCRIPTION
Don't call format_string if the command_xxx_format doesn't contains style syntax.
This will let the external command to take the responsibly for the output of the content. For example, this feature let conky output its result along with the raw color codes.