### PR TITLE
Draft: feat: remote control zjstatus with pipes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -127,9 +127,9 @@ checksum = "8901269c6307e8d93993578286ac0edf7f195079ffff5ebdeea6a59ffb7e36bc"
 
 [[package]]
 name = "anyhow"
-version = "1.0.80"
+version = "1.0.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ad32ce52e4161730f7098c077cd2ed6229b5804ccf99e5366be1ab72a98b4e1"
+checksum = "0952808a6c2afd1aa8947271f3a60f1a6763c7b912d210184c5149b5cf147247"
 dependencies = [
  "backtrace",
 ]
@@ -145,6 +145,16 @@ name = "arrayvec"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23b62fc65de8e4e7f52534fb52b0f3ed04746ae267519eef2a83941e8085068b"
+
+[[package]]
+name = "async-attributes"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3203e79f4dd9bdda415ed03cf14dae5a2bf775c683a00f94e9cd1faf0f596e5"
+dependencies = [
+ "quote",
+ "syn 1.0.109",
+]
 
 [[package]]
 name = "async-channel"
@@ -192,7 +202,7 @@ checksum = "05b1b633a2115cd122d73b955eadd9916c18c8f510ec9cd1686404c60ad1c29c"
 dependencies = [
  "async-channel 2.2.0",
  "async-executor",
- "async-io 2.3.1",
+ "async-io 2.3.2",
  "async-lock 3.3.0",
  "blocking",
  "futures-lite 2.2.0",
@@ -221,9 +231,9 @@ dependencies = [
 
 [[package]]
 name = "async-io"
-version = "2.3.1"
+version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f97ab0c5b00a7cdbe5a371b9a782ee7be1316095885c8a4ea1daf490eb0ef65"
+checksum = "dcccb0f599cfa2f8ace422d3555572f47424da5648a4382a9dd0310ff8210884"
 dependencies = [
  "async-lock 3.3.0",
  "cfg-if",
@@ -281,7 +291,7 @@ version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e47d90f65a225c4527103a8d747001fc56e375203592b25ad103e1ca13124c5"
 dependencies = [
- "async-io 2.3.1",
+ "async-io 2.3.2",
  "async-lock 2.8.0",
  "atomic-waker",
  "cfg-if",
@@ -299,6 +309,7 @@ version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "62565bb4402e926b29953c785397c6dc0391b7b446e45008b0049eb43cec6f5d"
 dependencies = [
+ "async-attributes",
  "async-channel 1.9.0",
  "async-global-executor",
  "async-io 1.13.0",
@@ -450,9 +461,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.15.3"
+version = "3.15.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ea184aa71bb362a1157c896979544cc23974e08fd265f29ea96b59f0b4a555b"
+checksum = "7ff69b9dd49fd426c69a0db9fc04dd934cdb6645ff000864d98f7e2af8830eaa"
 
 [[package]]
 name = "byteorder"
@@ -513,9 +524,9 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.0.89"
+version = "1.0.90"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0ba8f7aaa012f30d5b2861462f6708eccd49c3c39863fe083a308035f63d723"
+checksum = "8cd6604a82acf3039f1144f54b8eb34e91ffba622051189e71b781822d5ee1f5"
 
 [[package]]
 name = "cfg-if"
@@ -525,9 +536,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "chrono"
-version = "0.4.34"
+version = "0.4.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5bc015644b92d5890fab7489e49d21f879d5c990186827d42ec511919404f38b"
+checksum = "8eaf5903dcbc0a39312feb77df2ff4c76387d591b9fc7b04a238dcf8bb62639a"
 dependencies = [
  "android-tzdata",
  "iana-time-zone",
@@ -612,18 +623,18 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.1"
+version = "4.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c918d541ef2913577a0f9566e9ce27cb35b6df072075769e0b26cb5a554520da"
+checksum = "b230ab84b0ffdf890d5a10abdbc8b83ae1c4918275daea1ab8801f71536b2651"
 dependencies = [
  "clap_builder",
 ]
 
 [[package]]
 name = "clap_builder"
-version = "4.5.1"
+version = "4.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f3e7391dad68afb0c2ede1bf619f579a3dc9c2ec67f089baa397123a2f3d1eb"
+checksum = "ae129e2e766ae0ec03484e609954119f123cc1fe650337e155d03b022f24f7b4"
 dependencies = [
  "anstyle",
  "clap_lex 0.7.0",
@@ -763,7 +774,7 @@ dependencies = [
  "anes",
  "cast",
  "ciborium",
- "clap 4.5.1",
+ "clap 4.5.2",
  "criterion-plot",
  "is-terminal",
  "itertools",
@@ -2541,9 +2552,9 @@ checksum = "dc375e1527247fe1a97d8b7156678dfe7c1af2fc075c9a4db3690ecd2a148068"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.78"
+version = "1.0.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2422ad645d89c99f8f3e6b88a9fdeca7fabeac836b1002371c4367c8f984aae"
+checksum = "e835ff2298f5721608eb1a980ecaee1aef2c132bf95ecc026a11b7bf3c01c02e"
 dependencies = [
  "unicode-ident",
 ]
@@ -3384,18 +3395,18 @@ checksum = "23d434d3f8967a09480fb04132ebe0a3e088c173e6d0ee7897abbdf4eab0f8b9"
 
 [[package]]
 name = "thiserror"
-version = "1.0.57"
+version = "1.0.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e45bcbe8ed29775f228095caf2cd67af7a4ccf756ebff23a306bf3e8b47b24b"
+checksum = "03468839009160513471e86a034bb2c5c0e4baae3b43f79ffc55c4a5427b3297"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.57"
+version = "1.0.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a953cb265bef375dae3de6663da4d3804eee9682ea80d8e2542529b73c531c81"
+checksum = "c61f3ba182994efc43764a46c018c347bc492c79f024e705f46567b418f6d4f7"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3647,9 +3658,9 @@ dependencies = [
 
 [[package]]
 name = "value-bag"
-version = "1.7.0"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "126e423afe2dd9ac52142e7e9d5ce4135d7e13776c529d27fd6bc49f19e3280b"
+checksum = "8fec26a25bd6fca441cdd0f769fd7f891bae119f996de31f86a5eddccef54c1d"
 
 [[package]]
 name = "vcpkg"
@@ -4052,9 +4063,8 @@ checksum = "32b752e52a2da0ddfbdbcc6fceadfeede4c939ed16d13e648833a61dfb611ed8"
 
 [[package]]
 name = "zellij-tile"
-version = "0.39.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bee5e07b2425d3135e162740f99fe1594f43e5f0a62fe09e3002a8356c6a90cc"
+version = "0.40.0"
+source = "git+https://github.com/zellij-org/zellij#12daac3b5445e4281cf5c1810be0ebdb257085c1"
 dependencies = [
  "clap 3.2.25",
  "serde",
@@ -4066,9 +4076,8 @@ dependencies = [
 
 [[package]]
 name = "zellij-utils"
-version = "0.39.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2b8f21edd42f679b1aa3440add0c6a6539f91d81c6eee5f41e105d84342c037"
+version = "0.40.0"
+source = "git+https://github.com/zellij-org/zellij#12daac3b5445e4281cf5c1810be0ebdb257085c1"
 dependencies = [
  "anyhow",
  "async-channel 1.9.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ bench = false
 bench = []
 
 [dependencies]
-zellij-tile = "0.39.0"
+zellij-tile = "0.40.0"
 chrono = { version = "0.4.0", default-features = false }
 regex = "1.10.0"
 chrono-tz = "0.8.3"
@@ -36,3 +36,6 @@ harness = false
 [[bench]]
 name = "widgets"
 harness = false
+
+[patch.crates-io]
+zelij-tile = { git = 'https://github.com/zellij-org/zellij', package = 'zellij-tile' }

--- a/benches/widgets.rs
+++ b/benches/widgets.rs
@@ -19,7 +19,7 @@ fn bench_widget_command(c: &mut Criterion) {
 
     let wid = widgets::command::CommandWidget::new(&config);
 
-    let ts = Local::now().sub(Duration::seconds(1));
+    let ts = Local::now().sub(Duration::try_seconds(1).unwrap());
 
     let state = ZellijState {
         command_results: BTreeMap::from([(
@@ -56,7 +56,7 @@ fn bench_widget_command_dynamic(c: &mut Criterion) {
 
     let wid = widgets::command::CommandWidget::new(&config);
 
-    let ts = Local::now().sub(Duration::seconds(1));
+    let ts = Local::now().sub(Duration::try_seconds(1).unwrap());
 
     let state = ZellijState {
         command_results: BTreeMap::from([(

--- a/flake.lock
+++ b/flake.lock
@@ -7,11 +7,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1708794349,
-        "narHash": "sha256-jX+B1VGHT0ruHHL5RwS8L21R6miBn4B6s9iVyUJsJJY=",
+        "lastModified": 1710003968,
+        "narHash": "sha256-g8+K+mLiNG5uch35Oy9oDQBAmGSkCcqrd0Jjme7xiG0=",
         "owner": "ipetkov",
         "repo": "crane",
-        "rev": "2c94ff9a6fbeb9f3ea0107f28688edbe9c81deaa",
+        "rev": "10484f86201bb94bd61ecc5335b1496794fedb78",
         "type": "github"
       },
       "original": {
@@ -25,11 +25,11 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1709126324,
-        "narHash": "sha256-q6EQdSeUZOG26WelxqkmR7kArjgWCdw5sfJVHPH/7j8=",
+        "lastModified": 1710146030,
+        "narHash": "sha256-SZ5L6eA7HJ/nmkzGG7/ISclqe6oZdOZTNoesiInkXPQ=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "d465f4819400de7c8d874d50b982301f28a84605",
+        "rev": "b1d9ab70662946ef0850d488da1c9019f3a9752a",
         "type": "github"
       },
       "original": {
@@ -40,11 +40,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1709294055,
-        "narHash": "sha256-7EECkQYoNKJZOf2+miJdrMpxpvsn/qZFwIhUI3fQpLs=",
+        "lastModified": 1710252211,
+        "narHash": "sha256-hQChQpB4LDBaSrNlD6DPLhU9T+R6oyxMCg2V+S7Y1jg=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "ec869190b56a1b4677d24a8bdbcfe80ccea2ece6",
+        "rev": "7eeacecff44e05a9fd61b9e03836b66ecde8a525",
         "type": "github"
       },
       "original": {
@@ -72,11 +72,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1709259239,
-        "narHash": "sha256-MbrpgqpvUND7+UnOSLazrAMj0+zle16RRiOKTtjBefw=",
+        "lastModified": 1710209426,
+        "narHash": "sha256-A7bXK9k6RdBGsmqU4DxHqDBty7kKNkh8Pv+iGE2i1Ac=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "0e031ddb3f5a339dc6eda93d271ae43618b14eec",
+        "rev": "405cdc2652fa89f2fcf392335d5b9364b0adc5c2",
         "type": "github"
       },
       "original": {

--- a/src/bin/zjstatus.rs
+++ b/src/bin/zjstatus.rs
@@ -16,7 +16,7 @@ use uuid::Uuid;
 
 use zjstatus::{
     config::{self, UpdateEventMask, ZellijState},
-    frames, widgets,
+    frames, pipe, widgets,
 };
 
 #[derive(Default)]
@@ -68,6 +68,25 @@ impl ZellijPlugin for State {
             start_time: Local::now(),
             cache_mask: 0,
         };
+    }
+
+    fn pipe(&mut self, pipe_message: PipeMessage) -> bool {
+        let mut should_render = false;
+
+        match pipe_message.source {
+            PipeSource::Cli(_) => {
+                if let Some(input) = pipe_message.payload {
+                    should_render = pipe::parse_protocol(&mut self.state, &input);
+                }
+            }
+            PipeSource::Plugin(_) => {
+                if let Some(input) = pipe_message.payload {
+                    should_render = pipe::parse_protocol(&mut self.state, &input);
+                }
+            }
+        }
+
+        should_render
     }
 
     fn update(&mut self, event: Event) -> bool {

--- a/src/config.rs
+++ b/src/config.rs
@@ -336,7 +336,6 @@ impl ModuleConfig {
         // count of 0 on tab creation
         let space_count = center_pos.saturating_sub(text_count);
 
-        eprintln!("space_count: {:?}", space_count);
         self.format_space.format_string(&" ".repeat(space_count))
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod border;
 pub mod config;
 pub mod frames;
+pub mod pipe;
 pub mod render;
 pub mod widgets;

--- a/src/pipe.rs
+++ b/src/pipe.rs
@@ -1,0 +1,68 @@
+use std::ops::Sub;
+
+use chrono::{Duration, Local};
+
+use crate::{config::ZellijState, widgets::command::TIMESTAMP_FORMAT};
+
+/// Parses the line protocol and updates the state accordingly
+///
+/// The protocol is as follows:
+///
+/// zjstatus::command_name::args
+///
+/// It first starts with `zjstatus` as a prefix to indicate that the line is
+/// used for the line protocol and zjstatus should parse it. It is followed
+/// by the command name and then the arguments. The following commands are
+/// available:
+///
+/// - `rerun` - Reruns the command with the given name (like in the config) as
+///             argument. E.g. `zjstatus::rerun::command_1`
+///
+/// The function returns a boolean indicating whether the state has been
+/// changed and the UI should be re-rendered.
+pub fn parse_protocol(state: &mut ZellijState, input: &str) -> bool {
+    let parts = input.split("::").collect::<Vec<&str>>();
+
+    if parts.len() < 3 {
+        return false;
+    }
+
+    if parts[0] != "zjstatus" {
+        return false;
+    }
+
+    let mut should_render = false;
+    #[allow(clippy::single_match)]
+    match parts[1] {
+        "rerun" => {
+            rerun_command(state, parts[2]);
+
+            should_render = true;
+        }
+        _ => {}
+    }
+
+    should_render
+}
+
+fn rerun_command(state: &mut ZellijState, command_name: &str) {
+    let command_result = state.command_results.get(command_name);
+
+    if command_result.is_none() {
+        return;
+    }
+
+    let mut command_result = command_result.unwrap().clone();
+
+    let ts = Sub::<Duration>::sub(Local::now(), Duration::try_days(1).unwrap());
+
+    command_result.context.insert(
+        "timestamp".to_string(),
+        ts.format(TIMESTAMP_FORMAT).to_string(),
+    );
+
+    state.command_results.remove(command_name);
+    state
+        .command_results
+        .insert(command_name.to_string(), command_result.clone());
+}

--- a/src/pipe.rs
+++ b/src/pipe.rs
@@ -21,7 +21,7 @@ use crate::{config::ZellijState, widgets::command::TIMESTAMP_FORMAT};
 /// The function returns a boolean indicating whether the state has been
 /// changed and the UI should be re-rendered.
 pub fn parse_protocol(state: &mut ZellijState, input: &str) -> bool {
-    let lines = input.split("\n").collect::<Vec<&str>>();
+    let lines = input.split('\n').collect::<Vec<&str>>();
 
     let mut should_render = false;
     for line in lines {

--- a/src/pipe.rs
+++ b/src/pipe.rs
@@ -21,7 +21,22 @@ use crate::{config::ZellijState, widgets::command::TIMESTAMP_FORMAT};
 /// The function returns a boolean indicating whether the state has been
 /// changed and the UI should be re-rendered.
 pub fn parse_protocol(state: &mut ZellijState, input: &str) -> bool {
-    let parts = input.split("::").collect::<Vec<&str>>();
+    let lines = input.split("\n").collect::<Vec<&str>>();
+
+    let mut should_render = false;
+    for line in lines {
+        let line_renders = process_line(state, line);
+
+        if line_renders {
+            should_render = true;
+        }
+    }
+
+    should_render
+}
+
+fn process_line(state: &mut ZellijState, line: &str) -> bool {
+    let parts = line.split("::").collect::<Vec<&str>>();
 
     if parts.len() < 3 {
         return false;

--- a/src/widgets/command.rs
+++ b/src/widgets/command.rs
@@ -208,13 +208,13 @@ fn get_timestamp_from_event_or_default(
             return Local::now();
         }
 
-        return Sub::<Duration>::sub(Local::now(), Duration::days(1));
+        return Sub::<Duration>::sub(Local::now(), Duration::try_days(1).unwrap());
     }
     let command_result = command_result.unwrap();
 
     let ts_context = command_result.context.get("timestamp");
     if ts_context.is_none() {
-        return Sub::<Duration>::sub(Local::now(), Duration::days(1));
+        return Sub::<Duration>::sub(Local::now(), Duration::try_days(1).unwrap());
     }
     let ts_context = ts_context.unwrap();
 
@@ -224,7 +224,7 @@ fn get_timestamp_from_event_or_default(
 
     match DateTime::parse_from_str(ts_context, TIMESTAMP_FORMAT) {
         Ok(ts) => ts.into(),
-        Err(_) => Sub::<Duration>::sub(Local::now(), Duration::days(1)),
+        Err(_) => Sub::<Duration>::sub(Local::now(), Duration::try_days(1).unwrap()),
     }
 }
 


### PR DESCRIPTION
With the next release, zellij introduces [pipes for plugins](https://github.com/zellij-org/zellij/pull/3066), which allow to pipe arbitrary data to plugins. This allows us to implement a handler, that picks up the lines piped to zjstatus, such that it will be able to receive some commands.

In the first iteration zjstatus will gain the capability to rerun command widgets by sending a specific string through the pipe. To send such a message, simply run `zellij pipe "zjstatus::rerun::command_name" in the session where the command should be refreshed. Please note the appending specification for the protocol to communicate with zjstatus.

⚠️ This pull request can only be merged as soon as zellij releases its new version!

--- 

### Protocol description

As the name indicate, the protocol sends messages via lines. This means, that each line will try to be interpreted as one command. Each line has the following structure:

```
{{prefix}}::{{command}}::{{args}}
```

`{{prefix}}` is always `zjstatus`, such that zjstatus will be able to distinguish between messages for other plugins and itself. `{{command}}` is the command you want to transmit to zjstatus. As of now, only `rerun` is possible. The third part is variadic and can provide arguments to the command to run. In case of `rerun` it is the command name as written in the layouts (e.g. `command_date`).