### PR TITLE
Remove flake-utils pin from rust-overlay input.

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -13,10 +13,7 @@
 
     rust-overlay = {
       url = "github:oxalica/rust-overlay";
-      inputs = {
-        nixpkgs.follows = "nixpkgs";
-        flake-utils.follows = "flake-utils";
-      };
+      inputs.nixpkgs.follows = "nixpkgs";
     };
   };
 


### PR DESCRIPTION
flake-utils is no longer used in rust-overlay since https://github.com/oxalica/rust-overlay/pull/180