### PR TITLE
fix: update rust-overlay to fix build failure from upstream

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -64,11 +64,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1754880555,
-        "narHash": "sha256-tG6l0wiX8V8IvG4HFYY8IYN5vpNAxQ+UWunjjpE6SqU=",
+        "lastModified": 1762396738,
+        "narHash": "sha256-BarSecuxtzp1boERdABLkkoxQTi6s/V33lJwUbWLrLY=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "17c591a44e4eb77f05f27cd37e1cfc3f219c7fc4",
+        "rev": "c63598992afd54d215d54f2b764adc0484c2b159",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
There has been an upstream issue in `rust-overlay` causing an issue with unpacking rust correctly.

```
Running phase: unpackPhase
@nix { "action": "setPhase", "phase": "unpackPhase" }
unpacking source archive /nix/store/kk82l67p6za6jwp43wkha2a29m5w48a6-unknown
do not know how to unpack source archive /nix/store/kk82l67p6za6jwp43wkha2a29m5w48a6-unknown
```

This in turn causes a build failure of zjstatus from the current `flake.lock` file.

This PR updates the input for `rust-overlay` thereby fixing the issue and causing zjstatus to build correctly.

Resolves #199.