### PR TITLE
feat: right-click tab to close it

### DIFF
--- a/src/widgets/command.rs
+++ b/src/widgets/command.rs
@@ -139,7 +139,7 @@ impl Widget for CommandWidget {
         }
     }
 
-    fn process_click(&self, name: &str, _state: &ZellijState, _pos: usize) {
+    fn process_click(&self, name: &str, _state: &ZellijState, _pos: usize, _click_type: super::widget::ClickType) {
         let command_config = match self.config.get(name) {
             Some(cc) => cc,
             None => {

--- a/src/widgets/datetime.rs
+++ b/src/widgets/datetime.rs
@@ -105,5 +105,5 @@ impl Widget for DateTimeWidget {
             })
     }
 
-    fn process_click(&self, _name: &str, _state: &ZellijState, _pos: usize) {}
+    fn process_click(&self, _name: &str, _state: &ZellijState, _pos: usize, _click_type: super::widget::ClickType) {}
 }

--- a/src/widgets/mode.rs
+++ b/src/widgets/mode.rs
@@ -139,7 +139,7 @@ impl Widget for ModeWidget {
             })
     }
 
-    fn process_click(&self, _name: &str, _state: &ZellijState, _pos: usize) {}
+    fn process_click(&self, _name: &str, _state: &ZellijState, _pos: usize, _click_type: super::widget::ClickType) {}
 }
 
 impl ModeWidget {

--- a/src/widgets/notification.rs
+++ b/src/widgets/notification.rs
@@ -74,5 +74,5 @@ impl Widget for NotificationWidget {
         output.to_owned()
     }
 
-    fn process_click(&self, _name: &str, _state: &ZellijState, _pos: usize) {}
+    fn process_click(&self, _name: &str, _state: &ZellijState, _pos: usize, _click_type: super::widget::ClickType) {}
 }

--- a/src/widgets/pipe.rs
+++ b/src/widgets/pipe.rs
@@ -85,7 +85,7 @@ impl Widget for PipeWidget {
         }
     }
 
-    fn process_click(&self, _name: &str, _state: &crate::config::ZellijState, _pos: usize) {}
+    fn process_click(&self, _name: &str, _state: &crate::config::ZellijState, _pos: usize, _click_type: super::widget::ClickType) {}
 }
 
 fn render_dynamic_formatted_content(content: &str, config: &BTreeMap<String, String>) -> String {

--- a/src/widgets/session.rs
+++ b/src/widgets/session.rs
@@ -18,5 +18,5 @@ impl Widget for SessionWidget {
         }
     }
 
-    fn process_click(&self, _name: &str, _state: &ZellijState, _pos: usize) {}
+    fn process_click(&self, _name: &str, _state: &ZellijState, _pos: usize, _click_type: super::widget::ClickType) {}
 }

--- a/src/widgets/swap_layout.rs
+++ b/src/widgets/swap_layout.rs
@@ -66,7 +66,7 @@ impl Widget for SwapLayoutWidget {
         output
     }
 
-    fn process_click(&self, _name: &str, _state: &ZellijState, _pos: usize) {
+    fn process_click(&self, _name: &str, _state: &ZellijState, _pos: usize, _click_type: super::widget::ClickType) {
         next_swap_layout()
     }
 }

--- a/src/widgets/tabs.rs
+++ b/src/widgets/tabs.rs
@@ -2,12 +2,12 @@ use std::{cmp, collections::BTreeMap};
 
 use zellij_tile::{
     prelude::{InputMode, ModeInfo, PaneInfo, PaneManifest, TabInfo},
-    shim::switch_tab_to,
+    shim::{close_tab_with_index, switch_tab_to},
 };
 
 use crate::{config::ZellijState, render::FormattedPart};
 
-use super::widget::Widget;
+use super::widget::{ClickType, Widget};
 
 pub struct TabsWidget {
     active_tab_format: Vec<FormattedPart>,
@@ -149,7 +149,7 @@ impl Widget for TabsWidget {
         output
     }
 
-    fn process_click(&self, _name: &str, state: &ZellijState, pos: usize) {
+    fn process_click(&self, _name: &str, state: &ZellijState, pos: usize, click_type: ClickType) {
         let mut offset = 0;
         let mut counter = 0;
 
@@ -195,7 +195,10 @@ impl Widget for TabsWidget {
             let content_len = console::measure_text_width(&rendered_content);
 
             if pos > offset && pos < offset + content_len {
-                switch_tab_to(tab.position as u32 + 1);
+                match click_type {
+                    ClickType::Right => close_tab_with_index(tab.position),
+                    ClickType::Left => switch_tab_to(tab.position as u32 + 1),
+                }
 
                 break;
             }

--- a/src/widgets/widget.rs
+++ b/src/widgets/widget.rs
@@ -1,6 +1,12 @@
 use crate::config::ZellijState;
 
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum ClickType {
+    Left,
+    Right,
+}
+
 pub trait Widget {
     fn process(&self, name: &str, state: &ZellijState) -> String;
-    fn process_click(&self, name: &str, state: &ZellijState, pos: usize);
+    fn process_click(&self, name: &str, state: &ZellijState, pos: usize, click_type: ClickType);
 }


### PR DESCRIPTION
## Summary

- Adds a `ClickType` enum (`Left`, `Right`) to the `Widget` trait's `process_click` method
- Passes mouse button type from `handle_mouse_action` through `process_widget_click` to individual widgets
- The tabs widget now calls `close_tab_with_index` on right-click instead of `switch_tab_to`
- All other widgets receive the new parameter but ignore it (no behavior change)

## Motivation

Browser-style right-click-to-close on status bar tabs is a natural UX pattern. Currently zjstatus treats right-click identically to left-click (switches to the tab). This change makes right-click close the clicked tab instead.

## Test plan

- [x] All 18 existing tests pass
- [ ] Manual: left-click on tab still switches to it
- [ ] Manual: right-click on tab closes it

🤖 Generated with [Claude Code](https://claude.com/claude-code)