### PR TITLE
feat: add {mode_bg} and {mode_fg} color variables

### DIFF
--- a/src/render.rs
+++ b/src/render.rs
@@ -15,10 +15,20 @@ lazy_static! {
     static ref WIDGET_REGEX: Regex = Regex::new("(\\{[a-z_0-9]+\\})").unwrap();
 }
 
+#[derive(Clone, Copy, Debug, PartialEq, Default)]
+pub enum ColorSource {
+    #[default]
+    Static,
+    ModeFg,
+    ModeBg,
+}
+
 #[derive(Clone, Debug, PartialEq)]
 pub struct FormattedPart {
     pub fg: Option<Color>,
     pub bg: Option<Color>,
+    pub fg_source: ColorSource,
+    pub bg_source: ColorSource,
     pub us: Option<Color>,
     pub effects: anstyle::Effects,
     pub bold: bool,
@@ -100,11 +110,21 @@ impl FormattedPart {
 
         for part in parts {
             if part.starts_with("fg=") {
-                result.fg = parse_color(part.strip_prefix("fg=").unwrap(), config);
+                let color_val = part.strip_prefix("fg=").unwrap();
+                match color_val {
+                    "{mode_fg}" => result.fg_source = ColorSource::ModeFg,
+                    "{mode_bg}" => result.fg_source = ColorSource::ModeBg,
+                    _ => result.fg = parse_color(color_val, config),
+                }
             }
 
             if part.starts_with("bg=") {
-                result.bg = parse_color(part.strip_prefix("bg=").unwrap(), config);
+                let color_val = part.strip_prefix("bg=").unwrap();
+                match color_val {
+                    "{mode_fg}" => result.bg_source = ColorSource::ModeFg,
+                    "{mode_bg}" => result.bg_source = ColorSource::ModeBg,
+                    _ => result.bg = parse_color(color_val, config),
+                }
             }
 
             if part.starts_with("us=") {
@@ -243,6 +263,19 @@ impl FormattedPart {
 
         res
     }
+
+    pub fn update_dynamic_colors(&mut self, mode_fg: Option<Color>, mode_bg: Option<Color>) {
+        match self.fg_source {
+            ColorSource::ModeFg => self.fg = mode_fg,
+            ColorSource::ModeBg => self.fg = mode_bg,
+            ColorSource::Static => {}
+        }
+        match self.bg_source {
+            ColorSource::ModeFg => self.bg = mode_fg,
+            ColorSource::ModeBg => self.bg = mode_bg,
+            ColorSource::Static => {}
+        }
+    }
 }
 
 impl Default for FormattedPart {
@@ -250,6 +283,8 @@ impl Default for FormattedPart {
         Self {
             fg: None,
             bg: None,
+            fg_source: ColorSource::Static,
+            bg_source: ColorSource::Static,
             us: None,
             effects: anstyle::Effects::new(),
             bold: false,
@@ -351,38 +386,6 @@ fn parse_color(color: &str, config: &BTreeMap<String, String>) -> Option<Color> 
     None
 }
 
-pub fn color_to_format_string(color: Option<Color>) -> String {
-    match color {
-        None => "default".to_string(),
-        Some(color) => match color {
-            Color::Ansi(c) => ansi_color_to_name(c).to_string(),
-            Color::Ansi256(Ansi256Color(n)) => format!("{}", n),
-            Color::Rgb(RgbColor(r, g, b)) => format!("#{:02x}{:02x}{:02x}", r, g, b),
-        },
-    }
-}
-
-fn ansi_color_to_name(color: AnsiColor) -> &'static str {
-    match color {
-        AnsiColor::Black => "black",
-        AnsiColor::Red => "red",
-        AnsiColor::Green => "green",
-        AnsiColor::Yellow => "yellow",
-        AnsiColor::Blue => "blue",
-        AnsiColor::Magenta => "magenta",
-        AnsiColor::Cyan => "cyan",
-        AnsiColor::White => "white",
-        AnsiColor::BrightBlack => "bright_black",
-        AnsiColor::BrightRed => "bright_red",
-        AnsiColor::BrightGreen => "bright_green",
-        AnsiColor::BrightYellow => "bright_yellow",
-        AnsiColor::BrightBlue => "bright_blue",
-        AnsiColor::BrightMagenta => "bright_magenta",
-        AnsiColor::BrightCyan => "bright_cyan",
-        AnsiColor::BrightWhite => "bright_white",
-    }
-}
-
 fn color_by_name(color: &str) -> Option<AnsiColor> {
     match color {
         "black" => Some(AnsiColor::Black),
@@ -458,27 +461,79 @@ mod test {
     }
 
     #[test]
-    fn test_color_to_format_string() {
-        assert_eq!(color_to_format_string(None), "default");
+    fn test_dynamic_color_source_parsing() {
+        let config = BTreeMap::new();
 
-        assert_eq!(
-            color_to_format_string(Some(RgbColor(255, 0, 128).into())),
-            "#ff0080"
+        let part = FormattedPart::from_format_string(
+            "bg={mode_bg},fg={mode_fg},bold] {session} ",
+            &config,
         );
 
-        assert_eq!(
-            color_to_format_string(Some(AnsiColor::Red.into())),
-            "red"
+        assert_eq!(part.fg_source, ColorSource::ModeFg);
+        assert_eq!(part.bg_source, ColorSource::ModeBg);
+        assert_eq!(part.fg, None);
+        assert_eq!(part.bg, None);
+        assert!(part.content.contains("{session}"));
+    }
+
+    #[test]
+    fn test_static_color_source_unchanged() {
+        let config = BTreeMap::new();
+
+        let part = FormattedPart::from_format_string(
+            "bg=#31748f,fg=#191724] text",
+            &config,
         );
 
-        assert_eq!(
-            color_to_format_string(Some(AnsiColor::BrightCyan.into())),
-            "bright_cyan"
+        assert_eq!(part.fg_source, ColorSource::Static);
+        assert_eq!(part.bg_source, ColorSource::Static);
+        assert_eq!(part.fg, Some(RgbColor(0x19, 0x17, 0x24).into()));
+        assert_eq!(part.bg, Some(RgbColor(0x31, 0x74, 0x8f).into()));
+    }
+
+    #[test]
+    fn test_update_dynamic_colors() {
+        let config = BTreeMap::new();
+
+        let mut part = FormattedPart::from_format_string(
+            "bg={mode_bg},fg={mode_fg}] text",
+            &config,
         );
 
-        assert_eq!(
-            color_to_format_string(Some(Ansi256Color(42).into())),
-            "42"
+        let mode_fg = Some(RgbColor(0x19, 0x17, 0x24).into());
+        let mode_bg = Some(RgbColor(0x31, 0x74, 0x8f).into());
+
+        part.update_dynamic_colors(mode_fg, mode_bg);
+        assert_eq!(part.fg, mode_fg);
+        assert_eq!(part.bg, mode_bg);
+
+        // Switch to different mode colors
+        let new_fg = Some(RgbColor(0x18, 0x18, 0x25).into());
+        let new_bg = Some(RgbColor(0xeb, 0x6f, 0x92).into());
+
+        part.update_dynamic_colors(new_fg, new_bg);
+        assert_eq!(part.fg, new_fg);
+        assert_eq!(part.bg, new_bg);
+    }
+
+    #[test]
+    fn test_update_dynamic_colors_noop_on_static() {
+        let config = BTreeMap::new();
+
+        let mut part = FormattedPart::from_format_string(
+            "bg=#31748f,fg=#191724] text",
+            &config,
         );
+
+        let original_fg = part.fg;
+        let original_bg = part.bg;
+
+        part.update_dynamic_colors(
+            Some(RgbColor(0xff, 0x00, 0x00).into()),
+            Some(RgbColor(0x00, 0xff, 0x00).into()),
+        );
+
+        assert_eq!(part.fg, original_fg);
+        assert_eq!(part.bg, original_bg);
     }
 }

--- a/src/render.rs
+++ b/src/render.rs
@@ -351,6 +351,38 @@ fn parse_color(color: &str, config: &BTreeMap<String, String>) -> Option<Color> 
     None
 }
 
+pub fn color_to_format_string(color: Option<Color>) -> String {
+    match color {
+        None => "default".to_string(),
+        Some(color) => match color {
+            Color::Ansi(c) => ansi_color_to_name(c).to_string(),
+            Color::Ansi256(Ansi256Color(n)) => format!("{}", n),
+            Color::Rgb(RgbColor(r, g, b)) => format!("#{:02x}{:02x}{:02x}", r, g, b),
+        },
+    }
+}
+
+fn ansi_color_to_name(color: AnsiColor) -> &'static str {
+    match color {
+        AnsiColor::Black => "black",
+        AnsiColor::Red => "red",
+        AnsiColor::Green => "green",
+        AnsiColor::Yellow => "yellow",
+        AnsiColor::Blue => "blue",
+        AnsiColor::Magenta => "magenta",
+        AnsiColor::Cyan => "cyan",
+        AnsiColor::White => "white",
+        AnsiColor::BrightBlack => "bright_black",
+        AnsiColor::BrightRed => "bright_red",
+        AnsiColor::BrightGreen => "bright_green",
+        AnsiColor::BrightYellow => "bright_yellow",
+        AnsiColor::BrightBlue => "bright_blue",
+        AnsiColor::BrightMagenta => "bright_magenta",
+        AnsiColor::BrightCyan => "bright_cyan",
+        AnsiColor::BrightWhite => "bright_white",
+    }
+}
+
 fn color_by_name(color: &str) -> Option<AnsiColor> {
     match color {
         "black" => Some(AnsiColor::Black),
@@ -423,5 +455,30 @@ mod test {
 
         let result = parse_color("$blue", &config);
         assert_eq!(result, None);
+    }
+
+    #[test]
+    fn test_color_to_format_string() {
+        assert_eq!(color_to_format_string(None), "default");
+
+        assert_eq!(
+            color_to_format_string(Some(RgbColor(255, 0, 128).into())),
+            "#ff0080"
+        );
+
+        assert_eq!(
+            color_to_format_string(Some(AnsiColor::Red.into())),
+            "red"
+        );
+
+        assert_eq!(
+            color_to_format_string(Some(AnsiColor::BrightCyan.into())),
+            "bright_cyan"
+        );
+
+        assert_eq!(
+            color_to_format_string(Some(Ansi256Color(42).into())),
+            "42"
+        );
     }
 }


### PR DESCRIPTION
## Summary

- Add `{mode_bg}` and `{mode_fg}` placeholders that resolve to the current mode's background/foreground colors
- Extract colors from the active mode's format string (e.g. `mode_locked`, `mode_tmux`) and make them available for use in `format_left`, `format_center`, and `format_right`
- Colors are only resolved when mode changes, and only when the placeholders are actually used in the format strings

This enables styling other widgets (like `{session}`) to dynamically inherit the current mode's colors, e.g.:
```
format_left "{mode}#[bg={mode_bg},fg={mode_fg},bold] {session} #[default]{tabs}"
```

Closes #219

## Usage

```kdl
layout {
    default_tab_template {
        children
        pane size=1 borderless=true {
            plugin location="file:~/.config/zellij/plugins/zjstatus.wasm" {
                format_left   "{mode}#[bg={mode_bg},fg={mode_fg},bold] {session} #[bg=default,fg={mode_bg}]#[default] {tabs}"
                format_center ""
                format_right  "#[fg={mode_bg}]#[bg={mode_bg},fg={mode_fg},bold] {datetime} #[default]"
                format_space  ""

                datetime          "{format}"
                datetime_format   "%H:%M"
                datetime_timezone "Europe/Paris"

                mode_locked "#[bg=#31748f,fg=#191724,bold]  LOCKED "
                mode_tmux   "#[bg=#eb6f92,fg=#191724,bold]  COMMAND "
                mode_normal "#[bg=#31748f,fg=#191724,bold]  NORMAL "

                tab_normal  " {index}: {name} "
                tab_active  "#[bold] {index}: {name} "
            }
        }
    }
}
```

| Normal then Command |
|---------------------|
| <img width="1265" height="85" alt="image" src="https://github.com/user-attachments/assets/25447cde-3294-44c6-bc99-75e211471b9c" /> | 
<img width="1265" height="85" alt="image" src="https://github.com/user-attachments/assets/599f7aa1-0c1e-4f39-8991-9f34f9cb608f" /> | 

The session name and time widget dynamically inherit the current mode's colors using powerline slants (``, ``) for transitions. Switching between locked/normal (pine) and command (red) mode updates both ends of the bar.

## Implementation

- `ColorSource` enum (`Static`/`ModeFg`/`ModeBg`) on `FormattedPart` tracks dynamic color bindings at parse time
- Mode colors are precomputed once at init via `extract_mode_colors`, avoiding per-render config cloning or string replacement
- On mode change, `resolve_mode_colors` updates only the `fg`/`bg` fields of parts that opted in via `update_dynamic_colors`
- Fallback chain: mode-specific config → `mode_default_to_mode` → `mode_normal`

## Test plan

- [x] Unit tests for `ColorSource` parsing (`{mode_fg}`/`{mode_bg}` detected, static colors unchanged)
- [x] Unit tests for `update_dynamic_colors` (dynamic parts updated, static parts untouched)
- [x] Unit tests for `extract_mode_colors` (direct match, `default_to_mode` fallback, `mode_normal` fallback, no config)
- [x] Unit tests for `has_dynamic_colors` detection
- [x] Unit tests for `resolve_mode_colors` with mode switching and caching
- [x] Manual verification: configure `{mode_bg}`/`{mode_fg}` in layout and confirm colors change with mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)