### PR TITLE
feat: dynamic width-based tab truncation

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,6 +191,17 @@ The following widgets are available:
 - [swap layout](https://github.com/dj95/zjstatus/wiki/4-%E2%80%90-Widgets#swap-layout)
 - [tabs](https://github.com/dj95/zjstatus/wiki/4-%E2%80%90-Widgets#tabs)
 
+## 📐 Dynamic Tab Truncation
+
+When `tab_display_count` is not set, tabs are automatically fitted to the available width. The section containing `{tabs}` is detected and rendered last so the widget knows exactly how much space the other sections consume.
+
+- Tabs are added around the active tab (right-first) until the budget is exhausted
+- Boundary tabs that don't fully fit are partially shown with a `…` suffix, but only when 2+ tabs are hidden on that side (so the `+N` indicator always remains visible alongside the boundary tab)
+- The minimum width for a boundary tab matches the truncation indicator format width on that side
+- `tab_truncate_start_format` and `tab_truncate_end_format` are used for the `+N` indicators at each edge
+- Works with tabs in `format_left`, `format_center`, or `format_right`
+- Fully backward compatible: setting `tab_display_count` uses the existing fixed-count windowing
+
 ## 🚧 Development
 
 Make sure you have rust and the `wasm32-wasi` target installed. If using nix, you could utilize the nix-shell

--- a/src/bin/zjstatus.rs
+++ b/src/bin/zjstatus.rs
@@ -90,6 +90,7 @@ impl ZellijPlugin for State {
 
         self.state = ZellijState {
             cols: 0,
+            reserved_cols: 0,
             command_results: BTreeMap::new(),
             pipe_results: BTreeMap::new(),
             mode: ModeInfo::default(),

--- a/src/config.rs
+++ b/src/config.rs
@@ -14,6 +14,9 @@ use chrono::{DateTime, Local};
 #[derive(Default, Debug, Clone)]
 pub struct ZellijState {
     pub cols: usize,
+    /// Columns reserved by other bar sections (right + center).
+    /// Set by render_bar before processing the tabs widget.
+    pub reserved_cols: usize,
     pub command_results: BTreeMap<String, CommandResult>,
     pub pipe_results: BTreeMap<String, String>,
     pub mode: ModeInfo,
@@ -171,7 +174,7 @@ impl ModuleConfig {
 
     pub fn handle_mouse_action(
         &mut self,
-        state: ZellijState,
+        mut state: ZellijState,
         mouse: Mouse,
         widget_map: BTreeMap<String, Arc<dyn Widget>>,
     ) {
@@ -184,14 +187,6 @@ impl ModuleConfig {
             Mouse::Release(_, y) => y,
             Mouse::Hover(_, _) => return,
         };
-
-        let output_left = self.left_parts.iter_mut().fold("".to_owned(), |acc, part| {
-            format!(
-                "{}{}",
-                acc,
-                part.format_string_with_widgets(&widget_map, &state)
-            )
-        });
 
         let output_center = self
             .center_parts
@@ -214,6 +209,17 @@ impl ModuleConfig {
                     part.format_string_with_widgets(&widget_map, &state)
                 )
             });
+
+        state.reserved_cols =
+            console::measure_text_width(&output_right) + console::measure_text_width(&output_center);
+
+        let output_left = self.left_parts.iter_mut().fold("".to_owned(), |acc, part| {
+            format!(
+                "{}{}",
+                acc,
+                part.format_string_with_widgets(&widget_map, &state)
+            )
+        });
 
         let (output_left, output_center, output_right) = match self.hide_on_overlength {
             true => self.trim_output(&output_left, &output_center, &output_right, state.cols),
@@ -326,7 +332,7 @@ impl ModuleConfig {
 
     pub fn render_bar(
         &mut self,
-        state: ZellijState,
+        mut state: ZellijState,
         widget_map: BTreeMap<String, Arc<dyn Widget>>,
     ) -> String {
         if self.left_parts.is_empty() && self.center_parts.is_empty() && self.right_parts.is_empty()
@@ -334,13 +340,8 @@ impl ModuleConfig {
             return "No configuration found. See https://github.com/dj95/zjstatus/wiki/3-%E2%80%90-Configuration for more info".to_string();
         }
 
-        let output_left = self.left_parts.iter_mut().fold("".to_owned(), |acc, part| {
-            format!(
-                "{acc}{}",
-                part.format_string_with_widgets(&widget_map, &state)
-            )
-        });
-
+        // Render right and center first so we can measure their width
+        // and give the tabs widget a width budget for dynamic truncation.
         let output_center = self
             .center_parts
             .iter_mut()
@@ -360,6 +361,16 @@ impl ModuleConfig {
                     part.format_string_with_widgets(&widget_map, &state)
                 )
             });
+
+        state.reserved_cols =
+            console::measure_text_width(&output_right) + console::measure_text_width(&output_center);
+
+        let output_left = self.left_parts.iter_mut().fold("".to_owned(), |acc, part| {
+            format!(
+                "{acc}{}",
+                part.format_string_with_widgets(&widget_map, &state)
+            )
+        });
 
         let (output_left, output_center, output_right) = match self.hide_on_overlength {
             true => self.trim_output(&output_left, &output_center, &output_right, state.cols),

--- a/src/config.rs
+++ b/src/config.rs
@@ -14,8 +14,8 @@ use chrono::{DateTime, Local};
 #[derive(Default, Debug, Clone)]
 pub struct ZellijState {
     pub cols: usize,
-    /// Columns reserved by other bar sections (right + center).
-    /// Set by render_bar before processing the tabs widget.
+    /// Columns reserved by bar sections not containing the tabs widget.
+    /// Set before rendering the section that contains tabs.
     pub reserved_cols: usize,
     pub command_results: BTreeMap<String, CommandResult>,
     pub pipe_results: BTreeMap<String, String>,
@@ -172,6 +172,16 @@ impl ModuleConfig {
         })
     }
 
+    fn tabs_section(&self) -> Part {
+        if self.left_parts.iter().any(|p| p.content.contains("{tabs}")) {
+            Part::Left
+        } else if self.center_parts.iter().any(|p| p.content.contains("{tabs}")) {
+            Part::Center
+        } else {
+            Part::Right
+        }
+    }
+
     pub fn handle_mouse_action(
         &mut self,
         mut state: ZellijState,
@@ -188,38 +198,33 @@ impl ModuleConfig {
             Mouse::Hover(_, _) => return,
         };
 
-        let output_center = self
-            .center_parts
-            .iter_mut()
-            .fold("".to_owned(), |acc, part| {
-                format!(
-                    "{}{}",
-                    acc,
-                    part.format_string_with_widgets(&widget_map, &state)
-                )
-            });
+        let tabs_in = self.tabs_section();
+        let (mut output_left, mut output_center, mut output_right) =
+            (String::new(), String::new(), String::new());
 
-        let output_right = self
-            .right_parts
-            .iter_mut()
-            .fold("".to_owned(), |acc, part| {
-                format!(
-                    "{}{}",
-                    acc,
-                    part.format_string_with_widgets(&widget_map, &state)
-                )
-            });
+        if tabs_in != Part::Left {
+            output_left = render_parts(&mut self.left_parts, &widget_map, &state);
+        }
+        if tabs_in != Part::Center {
+            output_center = render_parts(&mut self.center_parts, &widget_map, &state);
+        }
+        if tabs_in != Part::Right {
+            output_right = render_parts(&mut self.right_parts, &widget_map, &state);
+        }
 
-        state.reserved_cols =
-            console::measure_text_width(&output_right) + console::measure_text_width(&output_center);
+        state.reserved_cols = console::measure_text_width(&output_left)
+            + console::measure_text_width(&output_center)
+            + console::measure_text_width(&output_right);
 
-        let output_left = self.left_parts.iter_mut().fold("".to_owned(), |acc, part| {
-            format!(
-                "{}{}",
-                acc,
-                part.format_string_with_widgets(&widget_map, &state)
-            )
-        });
+        match tabs_in {
+            Part::Left => output_left = render_parts(&mut self.left_parts, &widget_map, &state),
+            Part::Center => {
+                output_center = render_parts(&mut self.center_parts, &widget_map, &state)
+            }
+            Part::Right => {
+                output_right = render_parts(&mut self.right_parts, &widget_map, &state)
+            }
+        }
 
         let (output_left, output_center, output_right) = match self.hide_on_overlength {
             true => self.trim_output(&output_left, &output_center, &output_right, state.cols),
@@ -340,37 +345,35 @@ impl ModuleConfig {
             return "No configuration found. See https://github.com/dj95/zjstatus/wiki/3-%E2%80%90-Configuration for more info".to_string();
         }
 
-        // Render right and center first so we can measure their width
-        // and give the tabs widget a width budget for dynamic truncation.
-        let output_center = self
-            .center_parts
-            .iter_mut()
-            .fold("".to_owned(), |acc, part| {
-                format!(
-                    "{acc}{}",
-                    part.format_string_with_widgets(&widget_map, &state)
-                )
-            });
+        // Render sections without tabs first to measure their width,
+        // then render the tabs section with the remaining width budget.
+        let tabs_in = self.tabs_section();
+        let (mut output_left, mut output_center, mut output_right) =
+            (String::new(), String::new(), String::new());
 
-        let output_right = self
-            .right_parts
-            .iter_mut()
-            .fold("".to_owned(), |acc, part| {
-                format!(
-                    "{acc}{}",
-                    part.format_string_with_widgets(&widget_map, &state)
-                )
-            });
+        if tabs_in != Part::Left {
+            output_left = render_parts(&mut self.left_parts, &widget_map, &state);
+        }
+        if tabs_in != Part::Center {
+            output_center = render_parts(&mut self.center_parts, &widget_map, &state);
+        }
+        if tabs_in != Part::Right {
+            output_right = render_parts(&mut self.right_parts, &widget_map, &state);
+        }
 
-        state.reserved_cols =
-            console::measure_text_width(&output_right) + console::measure_text_width(&output_center);
+        state.reserved_cols = console::measure_text_width(&output_left)
+            + console::measure_text_width(&output_center)
+            + console::measure_text_width(&output_right);
 
-        let output_left = self.left_parts.iter_mut().fold("".to_owned(), |acc, part| {
-            format!(
-                "{acc}{}",
-                part.format_string_with_widgets(&widget_map, &state)
-            )
-        });
+        match tabs_in {
+            Part::Left => output_left = render_parts(&mut self.left_parts, &widget_map, &state),
+            Part::Center => {
+                output_center = render_parts(&mut self.center_parts, &widget_map, &state)
+            }
+            Part::Right => {
+                output_right = render_parts(&mut self.right_parts, &widget_map, &state)
+            }
+        }
 
         let (output_left, output_center, output_right) = match self.hide_on_overlength {
             true => self.trim_output(&output_left, &output_center, &output_right, state.cols),
@@ -518,6 +521,16 @@ impl ModuleConfig {
 
         self.format_space.format_string(&" ".repeat(space_count))
     }
+}
+
+fn render_parts(
+    parts: &mut [FormattedPart],
+    widget_map: &BTreeMap<String, Arc<dyn Widget>>,
+    state: &ZellijState,
+) -> String {
+    parts.iter_mut().fold(String::new(), |acc, part| {
+        format!("{acc}{}", part.format_string_with_widgets(widget_map, state))
+    })
 }
 
 fn parts_from_config(

--- a/src/widgets/tabs.rs
+++ b/src/widgets/tabs.rs
@@ -187,14 +187,6 @@ impl Widget for TabsWidget {
         let mut offset = 0;
         let window = self.visible_tab_window(state);
 
-        let active_pos = &state
-            .tabs
-            .iter()
-            .find(|t| t.active)
-            .expect("no active tab")
-            .position
-            + 1;
-
         if window.truncated_start > 0 {
             for f in &self.tab_truncate_start_format {
                 let mut content = f.content.clone();
@@ -207,7 +199,7 @@ impl Widget for TabsWidget {
                 offset += console::measure_text_width(&f.format_string(&content));
 
                 if pos <= offset {
-                    switch_tab_to(active_pos.saturating_sub(1) as u32);
+                    switch_tab_to(window.truncated_start as u32);
                     return;
                 }
             }
@@ -273,7 +265,8 @@ impl Widget for TabsWidget {
                 offset += console::measure_text_width(&f.format_string(&content));
 
                 if pos <= offset {
-                    switch_tab_to(cmp::min(active_pos + 1, state.tabs.len()) as u32);
+                    let target = state.tabs.len() - window.truncated_end + 1;
+                    switch_tab_to(target as u32);
                     return;
                 }
             }

--- a/src/widgets/tabs.rs
+++ b/src/widgets/tabs.rs
@@ -9,6 +9,18 @@ use crate::{config::ZellijState, render::FormattedPart};
 
 use super::widget::Widget;
 
+struct TabWindow {
+    truncated_start: usize,
+    truncated_end: usize,
+    tabs: Vec<TabInfo>,
+    /// Partially visible tab at the left edge, with max display width.
+    left_boundary: Option<(TabInfo, usize)>,
+    /// Partially visible tab at the right edge, with max display width.
+    right_boundary: Option<(TabInfo, usize)>,
+    /// Max total output width for the tab section (0 = no limit).
+    available: usize,
+}
+
 pub struct TabsWidget {
     active_tab_format: Vec<FormattedPart>,
     active_tab_fullscreen_format: Vec<FormattedPart>,
@@ -103,62 +115,69 @@ impl TabsWidget {
 
 impl Widget for TabsWidget {
     fn process(&self, _name: &str, state: &ZellijState) -> String {
-        // When tab_display_count is set, use the existing fixed-count windowing.
-        // Otherwise, dynamically truncate based on available width.
-        let display_count = match self.tab_display_count {
-            Some(_) => self.tab_display_count,
-            None if state.cols > 0 && state.reserved_cols > 0 => {
-                // Compute how many tabs fit in the available width.
-                let available = state.cols.saturating_sub(state.reserved_cols);
-                let count = self.count_tabs_fitting(
-                    &state.tabs, &state.panes, &state.mode, available,
-                );
-                Some(count)
-            },
-            None => None,
-        };
-
-        let (truncated_start, truncated_end, tabs) =
-            get_tab_window(&state.tabs, display_count);
-
+        let window = self.visible_tab_window(state);
         let mut output = "".to_owned();
-        let mut counter = 0;
 
-        if truncated_start > 0 {
+        if window.truncated_start > 0 {
             for f in &self.tab_truncate_start_format {
                 let mut content = f.content.clone();
 
                 if content.contains("{count}") {
-                    content = content.replace("{count}", (truncated_start).to_string().as_str());
+                    content =
+                        content.replace("{count}", (window.truncated_start).to_string().as_str());
                 }
 
                 output = format!("{output}{}", f.format_string(&content));
             }
         }
 
-        for tab in &tabs {
+        if let Some((ref tab, max_width)) = window.left_boundary {
+            let rendered = self.render_tab(tab, &state.panes, &state.mode);
+            output = format!(
+                "{output}{}",
+                console::truncate_str(&rendered, max_width, "\u{2026}")
+            );
+            if let Some(sep) = &self.separator {
+                output = format!("{output}{}", sep.format_string(&sep.content));
+            }
+        }
+
+        let tab_count = window.tabs.len();
+        for (i, tab) in window.tabs.iter().enumerate() {
             let content = self.render_tab(tab, &state.panes, &state.mode);
-            counter += 1;
 
             output = format!("{}{}", output, content);
 
-            if counter < tabs.len()
+            if (i + 1 < tab_count || window.right_boundary.is_some())
                 && let Some(sep) = &self.separator
             {
                 output = format!("{}{}", output, sep.format_string(&sep.content));
             }
         }
 
-        if truncated_end > 0 {
+        if let Some((ref tab, max_width)) = window.right_boundary {
+            let rendered = self.render_tab(tab, &state.panes, &state.mode);
+            output = format!(
+                "{output}{}",
+                console::truncate_str(&rendered, max_width, "\u{2026}")
+            );
+        }
+
+        if window.truncated_end > 0 {
             for f in &self.tab_truncate_end_format {
                 let mut content = f.content.clone();
 
                 if content.contains("{count}") {
-                    content = content.replace("{count}", (truncated_end).to_string().as_str());
+                    content =
+                        content.replace("{count}", (window.truncated_end).to_string().as_str());
                 }
 
                 output = format!("{output}{}", f.format_string(&content));
             }
+        }
+
+        if window.available > 0 && console::measure_text_width(&output) > window.available {
+            output = console::truncate_str(&output, window.available, "\u{2026}").to_string();
         }
 
         output
@@ -166,10 +185,7 @@ impl Widget for TabsWidget {
 
     fn process_click(&self, _name: &str, state: &ZellijState, pos: usize) {
         let mut offset = 0;
-        let mut counter = 0;
-
-        let (truncated_start, truncated_end, tabs) =
-            get_tab_window(&state.tabs, self.tab_display_count);
+        let window = self.visible_tab_window(state);
 
         let active_pos = &state
             .tabs
@@ -179,12 +195,13 @@ impl Widget for TabsWidget {
             .position
             + 1;
 
-        if truncated_start > 0 {
+        if window.truncated_start > 0 {
             for f in &self.tab_truncate_start_format {
                 let mut content = f.content.clone();
 
                 if content.contains("{count}") {
-                    content = content.replace("{count}", (truncated_end).to_string().as_str());
+                    content =
+                        content.replace("{count}", (window.truncated_end).to_string().as_str());
                 }
 
                 offset += console::measure_text_width(&f.format_string(&content));
@@ -195,12 +212,26 @@ impl Widget for TabsWidget {
             }
         }
 
-        for tab in &tabs {
-            counter += 1;
+        if let Some((ref tab, max_width)) = window.left_boundary {
+            let rendered = self.render_tab(tab, &state.panes, &state.mode);
+            let truncated = console::truncate_str(&rendered, max_width, "\u{2026}");
+            let mut content = truncated.to_string();
+            if let Some(sep) = &self.separator {
+                content = format!("{}{}", content, sep.format_string(&sep.content));
+            }
+            let content_len = console::measure_text_width(&content);
+            if pos > offset && pos < offset + content_len {
+                switch_tab_to(tab.position as u32 + 1);
+                return;
+            }
+            offset += content_len;
+        }
 
+        let tab_count = window.tabs.len();
+        for (i, tab) in window.tabs.iter().enumerate() {
             let mut rendered_content = self.render_tab(tab, &state.panes, &state.mode);
 
-            if counter < tabs.len()
+            if (i + 1 < tab_count || window.right_boundary.is_some())
                 && let Some(sep) = &self.separator
             {
                 rendered_content =
@@ -218,12 +249,24 @@ impl Widget for TabsWidget {
             offset += content_len;
         }
 
-        if truncated_end > 0 {
+        if let Some((ref tab, max_width)) = window.right_boundary {
+            let rendered = self.render_tab(tab, &state.panes, &state.mode);
+            let truncated = console::truncate_str(&rendered, max_width, "\u{2026}");
+            let content_len = console::measure_text_width(&truncated);
+            if pos > offset && pos < offset + content_len {
+                switch_tab_to(tab.position as u32 + 1);
+                return;
+            }
+            offset += content_len;
+        }
+
+        if window.truncated_end > 0 {
             for f in &self.tab_truncate_end_format {
                 let mut content = f.content.clone();
 
                 if content.contains("{count}") {
-                    content = content.replace("{count}", (truncated_end).to_string().as_str());
+                    content =
+                        content.replace("{count}", (window.truncated_end).to_string().as_str());
                 }
 
                 offset += console::measure_text_width(&f.format_string(&content));
@@ -237,27 +280,62 @@ impl Widget for TabsWidget {
 }
 
 impl TabsWidget {
-    /// Count how many tabs fit within the given column budget.
-    /// Accounts for separator width and truncation indicator width.
-    /// Always includes at least the active tab.
-    fn count_tabs_fitting(
+    /// Get the visible tab window. Uses fixed count windowing if tab_display_count
+    /// is configured, otherwise fits tabs to the available width.
+    fn visible_tab_window(&self, state: &ZellijState) -> TabWindow {
+        if self.tab_display_count.is_some() {
+            let (start, end, tabs) = get_tab_window(&state.tabs, self.tab_display_count);
+            return TabWindow {
+                truncated_start: start,
+                truncated_end: end,
+                tabs,
+                left_boundary: None,
+                right_boundary: None,
+                available: 0,
+            };
+        }
+        if state.cols > 0 {
+            let available = state.cols.saturating_sub(state.reserved_cols);
+            return self.fit_tab_window(&state.tabs, &state.panes, &state.mode, available);
+        }
+        TabWindow {
+            truncated_start: 0,
+            truncated_end: 0,
+            tabs: state.tabs.to_vec(),
+            left_boundary: None,
+            right_boundary: None,
+            available: 0,
+        }
+    }
+
+    /// Find the widest window of tabs around the active tab that fits within
+    /// the given column budget. Boundary tabs that don't fully fit are included
+    /// with a max display width for truncated rendering.
+    fn fit_tab_window(
         &self,
         tabs: &[TabInfo],
         panes: &PaneManifest,
         mode: &ModeInfo,
         available: usize,
-    ) -> usize {
+    ) -> TabWindow {
         if tabs.is_empty() {
-            return 0;
+            return TabWindow {
+                truncated_start: 0,
+                truncated_end: 0,
+                tabs: vec![],
+                left_boundary: None,
+                right_boundary: None,
+                available,
+            };
         }
 
-        // Measure truncation indicator width (used when tabs are truncated).
+        let max_count_str = tabs.len().to_string();
         let trunc_end_width: usize = self.tab_truncate_end_format.iter().map(|f| {
-            let content = f.content.replace("{count}", "99");
+            let content = f.content.replace("{count}", &max_count_str);
             console::measure_text_width(&f.format_string(&content))
         }).sum();
         let trunc_start_width: usize = self.tab_truncate_start_format.iter().map(|f| {
-            let content = f.content.replace("{count}", "99");
+            let content = f.content.replace("{count}", &max_count_str);
             console::measure_text_width(&f.format_string(&content))
         }).sum();
 
@@ -265,29 +343,27 @@ impl TabsWidget {
             .map(|s| console::measure_text_width(&s.format_string(&s.content)))
             .unwrap_or(0);
 
-        // Pre-render all tab widths.
         let tab_widths: Vec<usize> = tabs.iter()
             .map(|t| console::measure_text_width(&self.render_tab(t, panes, mode)))
             .collect();
 
-        // Try fitting all tabs first.
         let total: usize = tab_widths.iter().sum::<usize>()
             + sep_width * tabs.len().saturating_sub(1);
         if total <= available {
-            return tabs.len();
+            return TabWindow {
+                truncated_start: 0,
+                truncated_end: 0,
+                tabs: tabs.to_vec(),
+                left_boundary: None,
+                right_boundary: None,
+                available,
+            };
         }
 
-        // Find active tab index.
         let active_idx = tabs.iter().position(|t| t.active).unwrap_or(0);
-
-        // Grow window around active tab until budget is exceeded.
-        // Budget must reserve space for truncation indicators.
-        let mut count = 1;
-        let mut width = tab_widths[active_idx];
-
-        // Try adding tabs around the active one.
         let mut left = active_idx;
         let mut right = active_idx;
+        let mut width = tab_widths[active_idx];
 
         loop {
             let can_go_left = left > 0;
@@ -297,32 +373,26 @@ impl TabsWidget {
                 break;
             }
 
-            // Reserve space for truncation indicators that would appear.
-            let needs_start_trunc = left > 0 || (can_go_left && left.saturating_sub(1) > 0);
-            let needs_end_trunc = right + 1 < tabs.len()
-                || (can_go_right && right + 2 < tabs.len());
-            let trunc_reserve = if needs_start_trunc { trunc_start_width } else { 0 }
-                + if needs_end_trunc { trunc_end_width } else { 0 };
+            // Reserve space for truncation indicators after expanding right.
+            let trunc_reserve = if left > 0 { trunc_start_width } else { 0 }
+                + if right + 2 < tabs.len() { trunc_end_width } else { 0 };
 
-            // Try right first, then left.
             let mut grew = false;
             if can_go_right {
                 let candidate = width + sep_width + tab_widths[right + 1];
                 if candidate + trunc_reserve <= available {
                     right += 1;
                     width = candidate;
-                    count += 1;
                     grew = true;
                 }
             }
             if can_go_left {
-                let new_trunc_reserve = if left.saturating_sub(1) > 0 { trunc_start_width } else { 0 }
+                let new_trunc_reserve = if left > 1 { trunc_start_width } else { 0 }
                     + if right + 1 < tabs.len() { trunc_end_width } else { 0 };
                 let candidate = width + sep_width + tab_widths[left - 1];
                 if candidate + new_trunc_reserve <= available {
                     left -= 1;
                     width = candidate;
-                    count += 1;
                     grew = true;
                 }
             }
@@ -332,7 +402,47 @@ impl TabsWidget {
             }
         }
 
-        count
+        // Try to partially show boundary tabs in remaining space.
+        let start_trunc = if left > 0 { trunc_start_width } else { 0 };
+        let end_trunc = if right + 1 < tabs.len() { trunc_end_width } else { 0 };
+        let mut remaining = available.saturating_sub(width + start_trunc + end_trunc);
+
+        // Only show boundary tabs when 2+ tabs are hidden on that side,
+        // so the truncation indicator (with decremented count) always remains.
+        let mut right_boundary = None;
+        if right + 2 < tabs.len() {
+            let min_width = trunc_end_width.max(1);
+            let budget = remaining.saturating_sub(sep_width);
+            if budget >= min_width {
+                right_boundary = Some((tabs[right + 1].clone(), budget));
+                remaining = remaining.saturating_sub(sep_width + budget);
+            }
+        }
+
+        let mut left_boundary = None;
+        if left > 1 {
+            let min_width = trunc_start_width.max(1);
+            let budget = remaining.saturating_sub(sep_width);
+            if budget >= min_width {
+                left_boundary = Some((tabs[left - 1].clone(), budget));
+            }
+        }
+
+        let truncated_start = if left_boundary.is_some() { left - 1 } else { left };
+        let truncated_end = if right_boundary.is_some() {
+            tabs.len() - right - 2
+        } else {
+            tabs.len() - right - 1
+        };
+
+        TabWindow {
+            truncated_start,
+            truncated_end,
+            tabs: tabs[left..=right].to_vec(),
+            left_boundary,
+            right_boundary,
+            available,
+        }
     }
 
     fn select_format(&self, info: &TabInfo, mode: &ModeInfo) -> &Vec<FormattedPart> {

--- a/src/widgets/tabs.rs
+++ b/src/widgets/tabs.rs
@@ -201,13 +201,14 @@ impl Widget for TabsWidget {
 
                 if content.contains("{count}") {
                     content =
-                        content.replace("{count}", (window.truncated_end).to_string().as_str());
+                        content.replace("{count}", (window.truncated_start).to_string().as_str());
                 }
 
                 offset += console::measure_text_width(&f.format_string(&content));
 
                 if pos <= offset {
                     switch_tab_to(active_pos.saturating_sub(1) as u32);
+                    return;
                 }
             }
         }
@@ -273,6 +274,7 @@ impl Widget for TabsWidget {
 
                 if pos <= offset {
                     switch_tab_to(cmp::min(active_pos + 1, state.tabs.len()) as u32);
+                    return;
                 }
             }
         }

--- a/src/widgets/tabs.rs
+++ b/src/widgets/tabs.rs
@@ -103,11 +103,26 @@ impl TabsWidget {
 
 impl Widget for TabsWidget {
     fn process(&self, _name: &str, state: &ZellijState) -> String {
-        let mut output = "".to_owned();
-        let mut counter = 0;
+        // When tab_display_count is set, use the existing fixed-count windowing.
+        // Otherwise, dynamically truncate based on available width.
+        let display_count = match self.tab_display_count {
+            Some(_) => self.tab_display_count,
+            None if state.cols > 0 && state.reserved_cols > 0 => {
+                // Compute how many tabs fit in the available width.
+                let available = state.cols.saturating_sub(state.reserved_cols);
+                let count = self.count_tabs_fitting(
+                    &state.tabs, &state.panes, &state.mode, available,
+                );
+                Some(count)
+            },
+            None => None,
+        };
 
         let (truncated_start, truncated_end, tabs) =
-            get_tab_window(&state.tabs, self.tab_display_count);
+            get_tab_window(&state.tabs, display_count);
+
+        let mut output = "".to_owned();
+        let mut counter = 0;
 
         if truncated_start > 0 {
             for f in &self.tab_truncate_start_format {
@@ -222,6 +237,104 @@ impl Widget for TabsWidget {
 }
 
 impl TabsWidget {
+    /// Count how many tabs fit within the given column budget.
+    /// Accounts for separator width and truncation indicator width.
+    /// Always includes at least the active tab.
+    fn count_tabs_fitting(
+        &self,
+        tabs: &[TabInfo],
+        panes: &PaneManifest,
+        mode: &ModeInfo,
+        available: usize,
+    ) -> usize {
+        if tabs.is_empty() {
+            return 0;
+        }
+
+        // Measure truncation indicator width (used when tabs are truncated).
+        let trunc_end_width: usize = self.tab_truncate_end_format.iter().map(|f| {
+            let content = f.content.replace("{count}", "99");
+            console::measure_text_width(&f.format_string(&content))
+        }).sum();
+        let trunc_start_width: usize = self.tab_truncate_start_format.iter().map(|f| {
+            let content = f.content.replace("{count}", "99");
+            console::measure_text_width(&f.format_string(&content))
+        }).sum();
+
+        let sep_width = self.separator.as_ref()
+            .map(|s| console::measure_text_width(&s.format_string(&s.content)))
+            .unwrap_or(0);
+
+        // Pre-render all tab widths.
+        let tab_widths: Vec<usize> = tabs.iter()
+            .map(|t| console::measure_text_width(&self.render_tab(t, panes, mode)))
+            .collect();
+
+        // Try fitting all tabs first.
+        let total: usize = tab_widths.iter().sum::<usize>()
+            + sep_width * tabs.len().saturating_sub(1);
+        if total <= available {
+            return tabs.len();
+        }
+
+        // Find active tab index.
+        let active_idx = tabs.iter().position(|t| t.active).unwrap_or(0);
+
+        // Grow window around active tab until budget is exceeded.
+        // Budget must reserve space for truncation indicators.
+        let mut count = 1;
+        let mut width = tab_widths[active_idx];
+
+        // Try adding tabs around the active one.
+        let mut left = active_idx;
+        let mut right = active_idx;
+
+        loop {
+            let can_go_left = left > 0;
+            let can_go_right = right + 1 < tabs.len();
+
+            if !can_go_left && !can_go_right {
+                break;
+            }
+
+            // Reserve space for truncation indicators that would appear.
+            let needs_start_trunc = left > 0 || (can_go_left && left.saturating_sub(1) > 0);
+            let needs_end_trunc = right + 1 < tabs.len()
+                || (can_go_right && right + 2 < tabs.len());
+            let trunc_reserve = if needs_start_trunc { trunc_start_width } else { 0 }
+                + if needs_end_trunc { trunc_end_width } else { 0 };
+
+            // Try right first, then left.
+            let mut grew = false;
+            if can_go_right {
+                let candidate = width + sep_width + tab_widths[right + 1];
+                if candidate + trunc_reserve <= available {
+                    right += 1;
+                    width = candidate;
+                    count += 1;
+                    grew = true;
+                }
+            }
+            if can_go_left {
+                let new_trunc_reserve = if left.saturating_sub(1) > 0 { trunc_start_width } else { 0 }
+                    + if right + 1 < tabs.len() { trunc_end_width } else { 0 };
+                let candidate = width + sep_width + tab_widths[left - 1];
+                if candidate + new_trunc_reserve <= available {
+                    left -= 1;
+                    width = candidate;
+                    count += 1;
+                    grew = true;
+                }
+            }
+
+            if !grew {
+                break;
+            }
+        }
+
+        count
+    }
+
     fn select_format(&self, info: &TabInfo, mode: &ModeInfo) -> &Vec<FormattedPart> {
         if info.active && mode.mode == InputMode::RenameTab {
             return &self.rename_tab_format;


### PR DESCRIPTION
## Summary

- Tabs automatically fit to available width when `tab_display_count` is not set — no configuration needed
- The section containing `{tabs}` is detected and rendered last, so the widget knows exactly how much space other sections consume
- Works with tabs in `format_left`, `format_center`, or `format_right`
- Boundary tabs that don't fully fit are partially shown with a truncated name rather than hidden entirely
- Boundary tabs only appear when 2+ tabs are hidden on that side, so the `+N` indicator always remains visible
- Minimum boundary tab width matches the truncation indicator format width on each side
- Total tab output is clamped to prevent layout overflow on narrow terminals
- Indicator width estimation uses actual tab count instead of a hardcoded placeholder
- Fully backward compatible: `tab_display_count` still uses the existing fixed-count windowing
- Clicking `+N` indicators navigates to the nearest hidden tab on that side

## Test plan

- [ ] Build and run with `just run`, open 5-10 tabs
- [ ] Resize terminal — tabs should dynamically truncate/expand
- [ ] Verify boundary tabs show truncated names with `…` suffix
- [ ] Verify `+N` indicators appear when 1 tab is hidden (no boundary tab replacing it)
- [ ] Click `+N` start/end labels — should navigate to the nearest hidden tab
- [ ] Test with tabs in `format_left`, `format_center`, and `format_right`
- [ ] Test with `tab_display_count` set — should behave identically to before
- [ ] Narrow terminal to 1 visible tab — layout should not break