### PR TITLE
feat: add zero based tab index support

### DIFF
--- a/src/widgets/tabs.rs
+++ b/src/widgets/tabs.rs
@@ -24,7 +24,7 @@ pub struct TabsWidget {
     tab_display_count: Option<usize>,
     tab_truncate_start_format: Vec<FormattedPart>,
     tab_truncate_end_format: Vec<FormattedPart>,
-    tab_zero_based_index: Option<bool>,
+    tab_zero_based_index: bool,
 }
 
 impl TabsWidget {
@@ -80,10 +80,10 @@ impl TabsWidget {
             .unwrap_or_default();
 
         let tab_zero_based_index = match config.get("tab_zero_based_index") {
-            Some(e) => e.parse::<bool>().ok(),
-            None => None,
+            Some(e) => matches!(e.as_str(), "true"),
+            None => false,
         };
-        
+
         let separator = config
             .get("tab_separator")
             .map(|s| FormattedPart::from_format_string(s, config));
@@ -277,10 +277,9 @@ impl TabsWidget {
             }
 
             if content.contains("{index}") {
-                let index = if self.tab_zero_based_index.is_some_and(|x| x) {
-                    tab.position
-                } else {
-                    tab.position + 1
+                let index = match self.tab_zero_based_index {
+                    true => tab.position,
+                    false => tab.position + 1,
                 };
                 content = content.replace("{index}", index.to_string().as_str());
             }

--- a/src/widgets/tabs.rs
+++ b/src/widgets/tabs.rs
@@ -24,6 +24,7 @@ pub struct TabsWidget {
     tab_display_count: Option<usize>,
     tab_truncate_start_format: Vec<FormattedPart>,
     tab_truncate_end_format: Vec<FormattedPart>,
+    tab_zero_based_index: Option<bool>,
 }
 
 impl TabsWidget {
@@ -78,6 +79,11 @@ impl TabsWidget {
             .map(|form| FormattedPart::multiple_from_format_string(form, config))
             .unwrap_or_default();
 
+        let tab_zero_based_index = match config.get("tab_zero_based_index") {
+            Some(e) => e.parse::<bool>().ok(),
+            None => None,
+        };
+        
         let separator = config
             .get("tab_separator")
             .map(|s| FormattedPart::from_format_string(s, config));
@@ -97,6 +103,7 @@ impl TabsWidget {
             tab_display_count,
             tab_truncate_start_format,
             tab_truncate_end_format,
+            tab_zero_based_index,
         }
     }
 }
@@ -270,7 +277,12 @@ impl TabsWidget {
             }
 
             if content.contains("{index}") {
-                content = content.replace("{index}", (tab.position + 1).to_string().as_str());
+                let index = if self.tab_zero_based_index.is_some_and(|x| x) {
+                    tab.position
+                } else {
+                    tab.position + 1
+                };
+                content = content.replace("{index}", index.to_string().as_str());
             }
 
             if content.contains("{floating_total_count}") {

--- a/tests/zjstatus/layout.kdl
+++ b/tests/zjstatus/layout.kdl
@@ -51,6 +51,7 @@ layout {
             tab_display_count       "3"
             tab_truncate_start_format "#[fg=$blue,bg=$bg]#[bg=$blue,fg=black] +{count} ... #[fg=$bg,bg=$blue]"
             tab_truncate_end_format "#[fg=red,bg=$bg] ... +{count} > #[bg=$yellow] "
+            tab_zero_based_index "false"
 
             command_0_command      "echo \"平仮名, ひらがな 📦\""
             command_0_clickaction "bash -c \"zellij --session zjstatus-dev pipe 'zjstatus::notify::hello world!' -n zjstatus\""


### PR DESCRIPTION
This seeks to make the index match the underlying Zellij index so as to make it easier to, at a glance, switch tabs

<img width="391" height="53" alt="image" src="https://github.com/user-attachments/assets/7b8a807d-a604-4626-8673-64ee3ff95f15" />
<img width="340" height="69" alt="image" src="https://github.com/user-attachments/assets/4dc551a3-fc73-4119-af44-a256168270d7" />

