### PR TITLE
Add timer-driven idle refresh for zjstatus

### DIFF
--- a/src/bin/zjstatus.rs
+++ b/src/bin/zjstatus.rs
@@ -20,6 +20,9 @@ use zjstatus::{
     },
 };
 
+// Matches the old incidental Zellij session scan cadence.
+const REFRESH_INTERVAL_SECONDS: f64 = 1.0;
+
 #[derive(Default)]
 struct State {
     pending_events: Vec<Event>,
@@ -70,10 +73,12 @@ impl ZellijPlugin for State {
             EventType::ModeUpdate,
             EventType::PaneUpdate,
             EventType::PermissionRequestResult,
+            EventType::Timer,
             EventType::TabUpdate,
             EventType::SessionUpdate,
             EventType::RunCommandResult,
         ]);
+        set_timeout(REFRESH_INTERVAL_SECONDS);
 
         self.module_config = match ModuleConfig::new(&configuration) {
             Ok(mc) => mc,
@@ -291,6 +296,13 @@ impl State {
 
                 self.state.cache_mask = UpdateEventMask::Tab as u8;
                 self.state.tabs = tab_info;
+
+                should_render = true;
+            }
+            Event::Timer(_) => {
+                tracing::Span::current().record("event_type", "Event::Timer");
+                set_timeout(REFRESH_INTERVAL_SECONDS);
+                self.state.cache_mask = 0;
 
                 should_render = true;
             }


### PR DESCRIPTION
## Summary

- Subscribe `zjstatus` to Zellij's `Timer` event and start a 1-second timeout loop at plugin load.
- Re-arm the timeout on every timer event and request a render so datetime and command widgets continue updating while Zellij is idle.
- Reset the event cache mask on timer ticks so only always-refresh widgets bypass cache during idle refreshes.

## Motivation

Building Zellij from `main`, and presumably in zellij 0.45.0 when released, no longer emits the same incidental 1-second session update loop that previously caused `zjstatus` to render while idle (removed in Zellij [PR#5063](https://github.com/zellij-org/zellij/pull/5063), merged in commit [aa29cba](https://github.com/zellij-org/zellij/commit/aa29cbaf6631af0afca6aae427a97b3e478393b3)). Because command and datetime widgets decide whether to refresh during `render()`, they can stop updating until another Zellij action occurs, such as changing panes/tabs or applying a layout.

This makes `zjstatus` own its refresh clock via the existing Zellij plugin timer API instead of depending on unrelated session update behavior.

The 1-second cadence is set for this bug fix because it matches the previous Zellij session scan behavior. Making it configurable can be considered separately if there are requests for this, to tune battery or CPU behavior. Older Zellij versions may still provide incidental periodic updates, but command widgets remain throttled by their own intervals and timer ticks avoid invalidating state-driven widget caches.

## Related

- [#174](https://github.com/dj95/zjstatus/issues/174#issuecomment-4338397085): recent comment reports datetime and command widgets stop updating on Zellij 0.45.0 unless a Zellij action occurs.

## Testing

- `cargo build --release`
- `cargo nextest run --lib`
- `cargo clippy --all-features --lib`

Result: all succeeded locally. `cargo nextest run --lib` passed 18 tests.
