### PR TITLE
feat: dim status bar and gate segments by host/nested role

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,6 +177,45 @@ load_plugins {
 }
 ```
 
+## 🪆 Nested sessions
+
+This fork adds dimming and host/nested role awareness for Zellij 0.45's
+[nested session handling](https://zellij.dev/news/nested-sessions-kitty-graphics-new-ui/).
+
+- `dim_when_unfocused` (default `true`): when this session is not the one
+  currently receiving input (a host that has descended into a nested child,
+  or a nested session not currently ascended into), every rendered segment
+  is drawn with a muted palette instead of the normal theme colors, the same
+  signal core uses to dim pane chrome in the same situation.
+- `dim_strength` (default `0.5`, clamped to `0.0` to `1.0`): how strongly to
+  dim. `0.0` leaves colors unchanged, `1.0` blends them fully to neutral
+  gray. Only true RGB colors can be dimmed this way; named ANSI and
+  256-color palette entries render unchanged.
+- `only_when=host` / `only_when=nested`: a per-segment attribute, set
+  alongside `fg=`/`bg=` inside a `#[...]` prefix in `format_left`,
+  `format_center`, or `format_right`, that renders that segment only for a
+  host session or only for a nested one. A segment with no `only_when`
+  always renders. This lets one shared layout serve both roles instead of
+  maintaining two. It is not evaluated inside a widget's own per-item
+  format (`tab_normal`, `notification_format_unread`, and similar), only in
+  the three top-level format strings.
+
+```javascript
+format_left   "{mode} #[fg=#89B4FA,bold]{session}"
+format_right  "#[only_when=host]{command_weather} #[only_when=host]{datetime} #[]{command_resources}"
+
+dim_when_unfocused "true"
+dim_strength       "0.5"
+```
+
+The empty `#[]` before `{command_resources}` matters: without it, that
+token would be swallowed into the preceding `only_when=host` segment's
+content and inherit its condition, rather than rendering unconditionally
+as intended here.
+
+In this example, both a host and a nested session show mode, session name,
+and a resources widget, but only the host also shows weather and the clock.
+
 ## 🧱 Widgets
 
 The documentation for the widgets can be found in the [wiki](https://github.com/dj95/zjstatus/wiki/4-%E2%80%90-Widgets).

--- a/README.md
+++ b/README.md
@@ -191,6 +191,10 @@ This fork adds dimming and host/nested role awareness for Zellij 0.45's
   dim. `0.0` leaves colors unchanged, `1.0` blends them fully to neutral
   gray. Only true RGB colors can be dimmed this way; named ANSI and
   256-color palette entries render unchanged.
+- `dim_scope` (default `all`): which side of a nested-session pair
+  `dim_when_unfocused` applies to. `all` dims both a descended host and an
+  unascended nested session; `nested` leaves a descended host's own chrome
+  at full brightness and only dims nested sessions.
 - `only_when=host` / `only_when=nested`: a per-segment attribute, set
   alongside `fg=`/`bg=` inside a `#[...]` prefix in `format_left`,
   `format_center`, or `format_right`, that renders that segment only for a
@@ -198,7 +202,9 @@ This fork adds dimming and host/nested role awareness for Zellij 0.45's
   always renders. This lets one shared layout serve both roles instead of
   maintaining two. It is not evaluated inside a widget's own per-item
   format (`tab_normal`, `notification_format_unread`, and similar), only in
-  the three top-level format strings.
+  the three top-level format strings. A nested session that is currently
+  fullscreen within its host (covering the host's entire screen) counts as
+  a host for this check, since visually it is indistinguishable from one.
 
 ```javascript
 format_left   "{mode} #[fg=#89B4FA,bold]{session}"
@@ -206,6 +212,7 @@ format_right  "#[only_when=host]{command_weather} #[only_when=host]{datetime} #[
 
 dim_when_unfocused "true"
 dim_strength       "0.5"
+dim_scope          "all"
 ```
 
 The empty `#[]` before `{command_resources}` matters: without it, that

--- a/src/bin/zjstatus.rs
+++ b/src/bin/zjstatus.rs
@@ -97,6 +97,25 @@ impl ZellijPlugin for State {
         self.got_permissions = false;
         let uid = Uuid::new_v4();
 
+        // Read directly from `configuration` rather than going through
+        // `ModuleConfig`: these two live on `ZellijState`, not
+        // `ModuleConfig`, so every render-time call site that already has a
+        // `&ZellijState` (nearly everything, since it's the shared render
+        // context) can dim without also needing the module config threaded
+        // in. See `ZellijState::dim_amount`.
+        let dim_when_unfocused = match self.userspace_configuration.get("dim_when_unfocused") {
+            Some(toggle) => toggle == "true",
+            None => true,
+        };
+        // Clamped: dim_color's blend overshoots past neutral gray above
+        // 1.0, and inverts the blend direction below 0.0.
+        let dim_strength = self
+            .userspace_configuration
+            .get("dim_strength")
+            .and_then(|s| s.parse::<f32>().ok())
+            .unwrap_or(0.5)
+            .clamp(0.0, 1.0);
+
         self.state = ZellijState {
             cols: 0,
             command_results: BTreeMap::new(),
@@ -111,6 +130,8 @@ impl ZellijPlugin for State {
             incoming_notification: None,
             focused_pane_id: None,
             focused_pane_cwd: None,
+            dim_when_unfocused,
+            dim_strength,
         };
     }
 

--- a/src/bin/zjstatus.rs
+++ b/src/bin/zjstatus.rs
@@ -5,7 +5,7 @@ use std::{collections::BTreeMap, path::PathBuf, sync::Arc};
 use uuid::Uuid;
 
 use zjstatus::{
-    config::{self, ModuleConfig, UpdateEventMask, ZellijState},
+    config::{self, DimScope, ModuleConfig, UpdateEventMask, ZellijState},
     frames, pipe,
     widgets::{
         command::{CommandResult, CommandWidget},
@@ -98,7 +98,7 @@ impl ZellijPlugin for State {
         let uid = Uuid::new_v4();
 
         // Read directly from `configuration` rather than going through
-        // `ModuleConfig`: these two live on `ZellijState`, not
+        // `ModuleConfig`: these three live on `ZellijState`, not
         // `ModuleConfig`, so every render-time call site that already has a
         // `&ZellijState` (nearly everything, since it's the shared render
         // context) can dim without also needing the module config threaded
@@ -115,6 +115,10 @@ impl ZellijPlugin for State {
             .and_then(|s| s.parse::<f32>().ok())
             .unwrap_or(0.5)
             .clamp(0.0, 1.0);
+        let dim_scope = match self.userspace_configuration.get("dim_scope") {
+            Some(scope) if scope == "nested" => DimScope::NestedOnly,
+            _ => DimScope::All,
+        };
 
         self.state = ZellijState {
             cols: 0,
@@ -132,6 +136,7 @@ impl ZellijPlugin for State {
             focused_pane_cwd: None,
             dim_when_unfocused,
             dim_strength,
+            dim_scope,
         };
     }
 

--- a/src/border.rs
+++ b/src/border.rs
@@ -31,8 +31,8 @@ impl Default for BorderConfig {
 }
 
 impl BorderConfig {
-    pub fn draw(&self, cols: usize) -> String {
-        self.format.format_string(&self.char.repeat(cols))
+    pub fn draw(&self, cols: usize, dim: f32) -> String {
+        self.format.format_string(&self.char.repeat(cols), dim)
     }
 }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -26,6 +26,34 @@ pub struct ZellijState {
     pub cache_mask: u8,
     pub focused_pane_id: Option<PaneId>,
     pub focused_pane_cwd: Option<std::path::PathBuf>,
+    /// Config-time toggle for nested-session dimming (`dim_when_unfocused`,
+    /// default `true`). Lives on state, not just `ModuleConfig`, so that
+    /// every render-time call site that already has a `&ZellijState` (most
+    /// of them, since it's the shared render context) can call
+    /// `dim_amount()` without also needing the module config threaded in.
+    pub dim_when_unfocused: bool,
+    /// How strongly to dim, in `render::dim_color`'s `0.0..=1.0` scale.
+    /// Parsed from the `dim_strength` config option.
+    pub dim_strength: f32,
+}
+
+impl ZellijState {
+    /// The dim strength to render with right now: `0.0` (no change) unless
+    /// `dim_when_unfocused` is enabled and this session is currently the
+    /// dimmed side of a nested-session pair, a host that has descended
+    /// into a child, or a nested session not currently ascended into.
+    /// `session_ascended`/`session_dimmed` are the same fields core's own
+    /// bundled tab-bar/compact-bar plugins use for this exact purpose.
+    pub fn dim_amount(&self) -> f32 {
+        let is_dimmed =
+            self.mode.session_ascended == Some(true) || self.mode.session_dimmed == Some(true);
+
+        if self.dim_when_unfocused && is_dimmed {
+            self.dim_strength
+        } else {
+            0.0
+        }
+    }
 }
 
 #[derive(Clone, Debug, Ord, Eq, PartialEq, PartialOrd, Copy)]
@@ -194,6 +222,7 @@ impl ModuleConfig {
             Mouse::Release(_, y) => y,
             Mouse::Hover(_, _) => return,
         };
+        let dim = state.dim_amount();
 
         let output_left = self.left_parts.iter_mut().fold("".to_owned(), |acc, part| {
             format!(
@@ -244,6 +273,7 @@ impl ModuleConfig {
                 &output_left,
                 &output_center,
                 state.cols,
+                dim,
             ));
 
             offset += self.process_widget_click(
@@ -262,12 +292,14 @@ impl ModuleConfig {
                 &output_right,
                 &output_center,
                 state.cols,
+                dim,
             ));
         } else {
             offset += console::measure_text_width(&self.get_spacer(
                 &output_left,
                 &output_right,
                 state.cols,
+                dim,
             ));
         }
 
@@ -376,15 +408,17 @@ impl ModuleConfig {
             false => (output_left, output_center, output_right),
         };
 
+        let dim = state.dim_amount();
+
         if self.border.enabled {
             let mut border_top = "".to_owned();
             if self.border.enabled && self.border.position == BorderPosition::Top {
-                border_top = format!("{}\n", self.border.draw(state.cols));
+                border_top = format!("{}\n", self.border.draw(state.cols, dim));
             }
 
             let mut border_bottom = "".to_owned();
             if self.border.enabled && self.border.position == BorderPosition::Bottom {
-                border_bottom = format!("\n{}", self.border.draw(state.cols));
+                border_bottom = format!("\n{}", self.border.draw(state.cols, dim));
             }
 
             if !output_center.is_empty() {
@@ -392,9 +426,9 @@ impl ModuleConfig {
                     "{}{}{}{}{}{}{}",
                     border_top,
                     output_left,
-                    self.get_spacer_left(&output_left, &output_center, state.cols),
+                    self.get_spacer_left(&output_left, &output_center, state.cols, dim),
                     output_center,
-                    self.get_spacer_right(&output_right, &output_center, state.cols),
+                    self.get_spacer_right(&output_right, &output_center, state.cols, dim),
                     output_right,
                     border_bottom,
                 );
@@ -404,7 +438,7 @@ impl ModuleConfig {
                 "{}{}{}{}{}",
                 border_top,
                 output_left,
-                self.get_spacer(&output_left, &output_right, state.cols),
+                self.get_spacer(&output_left, &output_right, state.cols, dim),
                 output_right,
                 border_bottom,
             );
@@ -414,9 +448,9 @@ impl ModuleConfig {
             return format!(
                 "{}{}{}{}{}",
                 output_left,
-                self.get_spacer_left(&output_left, &output_center, state.cols),
+                self.get_spacer_left(&output_left, &output_center, state.cols, dim),
                 output_center,
-                self.get_spacer_right(&output_right, &output_center, state.cols),
+                self.get_spacer_right(&output_right, &output_center, state.cols, dim),
                 output_right,
             );
         }
@@ -424,7 +458,7 @@ impl ModuleConfig {
         format!(
             "{}{}{}",
             output_left,
-            self.get_spacer(&output_left, &output_right, state.cols),
+            self.get_spacer(&output_left, &output_right, state.cols, dim),
             output_right,
         )
     }
@@ -478,7 +512,13 @@ impl ModuleConfig {
     }
 
     #[tracing::instrument(skip_all)]
-    fn get_spacer_left(&self, output_left: &str, output_center: &str, cols: usize) -> String {
+    fn get_spacer_left(
+        &self,
+        output_left: &str,
+        output_center: &str,
+        cols: usize,
+        dim: f32,
+    ) -> String {
         let text_count = console::measure_text_width(output_left)
             + (console::measure_text_width(output_center) as f32 / 2.0).floor() as usize;
 
@@ -489,11 +529,18 @@ impl ModuleConfig {
         let space_count = center_pos.saturating_sub(text_count);
 
         tracing::debug!("space_count: {:?}", space_count);
-        self.format_space.format_string(&" ".repeat(space_count))
+        self.format_space
+            .format_string(&" ".repeat(space_count), dim)
     }
 
     #[tracing::instrument(skip_all)]
-    fn get_spacer_right(&self, output_right: &str, output_center: &str, cols: usize) -> String {
+    fn get_spacer_right(
+        &self,
+        output_right: &str,
+        output_center: &str,
+        cols: usize,
+        dim: f32,
+    ) -> String {
         let text_count = console::measure_text_width(output_right)
             + (console::measure_text_width(output_center) as f32 / 2.0).ceil() as usize;
 
@@ -504,10 +551,11 @@ impl ModuleConfig {
         let space_count = center_pos.saturating_sub(text_count);
 
         tracing::debug!("space_count: {:?}", space_count);
-        self.format_space.format_string(&" ".repeat(space_count))
+        self.format_space
+            .format_string(&" ".repeat(space_count), dim)
     }
 
-    fn get_spacer(&self, output_left: &str, output_right: &str, cols: usize) -> String {
+    fn get_spacer(&self, output_left: &str, output_right: &str, cols: usize, dim: f32) -> String {
         let text_count =
             console::measure_text_width(output_left) + console::measure_text_width(output_right);
 
@@ -515,7 +563,8 @@ impl ModuleConfig {
         // count of 0 on tab creation
         let space_count = cols.saturating_sub(text_count);
 
-        self.format_space.format_string(&" ".repeat(space_count))
+        self.format_space
+            .format_string(&" ".repeat(space_count), dim)
     }
 }
 
@@ -556,5 +605,48 @@ mod test {
                 ..Default::default()
             },
         )
+    }
+
+    fn state_with(
+        dim_when_unfocused: bool,
+        dim_strength: f32,
+        session_ascended: Option<bool>,
+        session_dimmed: Option<bool>,
+    ) -> ZellijState {
+        ZellijState {
+            mode: ModeInfo {
+                session_ascended,
+                session_dimmed,
+                ..Default::default()
+            },
+            dim_when_unfocused,
+            dim_strength,
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn test_dim_amount_when_not_dimmed() {
+        let state = state_with(true, 0.5, Some(false), None);
+        assert_eq!(state.dim_amount(), 0.0);
+    }
+
+    #[test]
+    fn test_dim_amount_when_session_ascended() {
+        let state = state_with(true, 0.5, Some(true), None);
+        assert_eq!(state.dim_amount(), 0.5);
+    }
+
+    #[test]
+    fn test_dim_amount_when_session_dimmed() {
+        let state = state_with(true, 0.7, None, Some(true));
+        assert_eq!(state.dim_amount(), 0.7);
+    }
+
+    #[test]
+    fn test_dim_amount_respects_config_toggle() {
+        // Dimmed by the session, but the user has turned the feature off.
+        let state = state_with(false, 0.5, Some(true), Some(true));
+        assert_eq!(state.dim_amount(), 0.0);
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -11,6 +11,19 @@ use crate::{
 };
 use chrono::{DateTime, Local};
 
+/// Which sessions `dim_when_unfocused` applies to. Parsed from the
+/// `dim_scope` config option.
+#[derive(Default, Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DimScope {
+    /// Dim both a host that has descended into a nested child and a nested
+    /// session not currently ascended into.
+    #[default]
+    All,
+    /// Dim only a nested session not currently ascended into; leave a
+    /// descended host's own chrome at full brightness.
+    NestedOnly,
+}
+
 #[derive(Default, Debug, Clone)]
 pub struct ZellijState {
     pub cols: usize,
@@ -35,20 +48,30 @@ pub struct ZellijState {
     /// How strongly to dim, in `render::dim_color`'s `0.0..=1.0` scale.
     /// Parsed from the `dim_strength` config option.
     pub dim_strength: f32,
+    /// Which sessions dimming applies to. Parsed from the `dim_scope`
+    /// config option.
+    pub dim_scope: DimScope,
 }
 
 impl ZellijState {
     /// The dim strength to render with right now: `0.0` (no change) unless
-    /// `dim_when_unfocused` is enabled and this session is currently the
-    /// dimmed side of a nested-session pair, a host that has descended
-    /// into a child, or a nested session not currently ascended into.
-    /// `session_ascended`/`session_dimmed` are the same fields core's own
-    /// bundled tab-bar/compact-bar plugins use for this exact purpose.
+    /// `dim_when_unfocused` is enabled, this session is currently the
+    /// dimmed side of a nested-session pair (a host that has descended
+    /// into a child, or a nested session not currently ascended into),
+    /// and `dim_scope` includes it. `session_ascended`/`session_dimmed`
+    /// are the same fields core's own bundled tab-bar/compact-bar plugins
+    /// use for this exact purpose.
     pub fn dim_amount(&self) -> f32 {
         let is_dimmed =
             self.mode.session_ascended == Some(true) || self.mode.session_dimmed == Some(true);
+        let in_scope = match self.dim_scope {
+            DimScope::All => true,
+            // `session_ancestry` is only non-empty for a nested session,
+            // so this excludes a host that has merely descended.
+            DimScope::NestedOnly => !self.mode.session_ancestry.is_empty(),
+        };
 
-        if self.dim_when_unfocused && is_dimmed {
+        if self.dim_when_unfocused && is_dimmed && in_scope {
             self.dim_strength
         } else {
             0.0
@@ -610,6 +633,8 @@ mod test {
     fn state_with(
         dim_when_unfocused: bool,
         dim_strength: f32,
+        dim_scope: DimScope,
+        session_ancestry: Vec<String>,
         session_ascended: Option<bool>,
         session_dimmed: Option<bool>,
     ) -> ZellijState {
@@ -617,36 +642,73 @@ mod test {
             mode: ModeInfo {
                 session_ascended,
                 session_dimmed,
+                session_ancestry,
                 ..Default::default()
             },
             dim_when_unfocused,
             dim_strength,
+            dim_scope,
             ..Default::default()
         }
     }
 
     #[test]
     fn test_dim_amount_when_not_dimmed() {
-        let state = state_with(true, 0.5, Some(false), None);
+        let state = state_with(true, 0.5, DimScope::All, vec![], Some(false), None);
         assert_eq!(state.dim_amount(), 0.0);
     }
 
     #[test]
     fn test_dim_amount_when_session_ascended() {
-        let state = state_with(true, 0.5, Some(true), None);
+        let state = state_with(
+            true,
+            0.5,
+            DimScope::All,
+            vec!["main".to_owned()],
+            Some(true),
+            None,
+        );
         assert_eq!(state.dim_amount(), 0.5);
     }
 
     #[test]
     fn test_dim_amount_when_session_dimmed() {
-        let state = state_with(true, 0.7, None, Some(true));
+        let state = state_with(true, 0.7, DimScope::All, vec![], None, Some(true));
         assert_eq!(state.dim_amount(), 0.7);
     }
 
     #[test]
     fn test_dim_amount_respects_config_toggle() {
         // Dimmed by the session, but the user has turned the feature off.
-        let state = state_with(false, 0.5, Some(true), Some(true));
+        let state = state_with(
+            false,
+            0.5,
+            DimScope::All,
+            vec!["main".to_owned()],
+            Some(true),
+            Some(true),
+        );
+        assert_eq!(state.dim_amount(), 0.0);
+    }
+
+    #[test]
+    fn test_dim_amount_nested_only_dims_nested_session() {
+        let state = state_with(
+            true,
+            0.5,
+            DimScope::NestedOnly,
+            vec!["main".to_owned()],
+            Some(true),
+            None,
+        );
+        assert_eq!(state.dim_amount(), 0.5);
+    }
+
+    #[test]
+    fn test_dim_amount_nested_only_ignores_descended_host() {
+        // A host that has descended has no ancestry of its own, so
+        // NestedOnly should leave its chrome at full brightness.
+        let state = state_with(true, 0.5, DimScope::NestedOnly, vec![], None, Some(true));
         assert_eq!(state.dim_amount(), 0.0);
     }
 }

--- a/src/render.rs
+++ b/src/render.rs
@@ -15,6 +15,24 @@ lazy_static! {
     static ref WIDGET_REGEX: Regex = Regex::new("(\\{[a-z_0-9]+\\})").unwrap();
 }
 
+/// Which session role a segment configured with `only_when=` renders for.
+/// A segment with no `only_when` attribute renders for both.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum Role {
+    Host,
+    Nested,
+}
+
+impl Role {
+    fn from_config_value(value: &str) -> Option<Self> {
+        match value {
+            "host" => Some(Role::Host),
+            "nested" => Some(Role::Nested),
+            _ => None,
+        }
+    }
+}
+
 #[derive(Clone, Debug, PartialEq)]
 pub struct FormattedPart {
     pub fg: Option<Color>,
@@ -33,6 +51,7 @@ pub struct FormattedPart {
     pub curly_underscore: bool,
     pub dotted_underscore: bool,
     pub dashed_underscore: bool,
+    pub only_when: Option<Role>,
     pub content: String,
     pub cache_mask: u8,
     pub cached_content: String,
@@ -111,6 +130,10 @@ impl FormattedPart {
                 result.us = parse_color(part.strip_prefix("us=").unwrap(), config);
             }
 
+            if let Some(role) = part.strip_prefix("only_when=") {
+                result.only_when = Role::from_config_value(role);
+            }
+
             if part.eq("reverse") {
                 result.reverse = true;
             }
@@ -163,12 +186,28 @@ impl FormattedPart {
         }
     }
 
-    pub fn format_string(&self, text: &str) -> String {
+    /// Renders `text` with this part's configured styling. `dim` is a
+    /// strength in `0.0..=1.0`; `0.0` renders normally, anything above that
+    /// blends `fg`/`bg`/`us` toward neutral gray by that fraction (see
+    /// `dim_color`). Callers derive it from `ZellijState::dim_amount`, which
+    /// is `0.0` unless this session is currently the dimmed side of a
+    /// nested-session pair.
+    pub fn format_string(&self, text: &str, dim: f32) -> String {
         let mut style = Style::new();
 
-        style = style.fg_color(self.fg);
-        style = style.bg_color(self.bg);
-        style = style.underline_color(self.us);
+        let (fg, bg, us) = if dim > 0.0 {
+            (
+                self.fg.map(|c| dim_color(c, dim)),
+                self.bg.map(|c| dim_color(c, dim)),
+                self.us.map(|c| dim_color(c, dim)),
+            )
+        } else {
+            (self.fg, self.bg, self.us)
+        };
+
+        style = style.fg_color(fg);
+        style = style.bg_color(bg);
+        style = style.underline_color(us);
         style = style.effects(self.effects);
 
         format!(
@@ -180,12 +219,28 @@ impl FormattedPart {
         )
     }
 
+    /// Whether this part should render at all given the session's current
+    /// host/nested role. A part with no `only_when` attribute always
+    /// matches; `session_ancestry` being non-empty means this session is
+    /// nested inside another one.
+    fn role_matches(&self, state: &ZellijState) -> bool {
+        match self.only_when {
+            None => true,
+            Some(Role::Host) => state.mode.session_ancestry.is_empty(),
+            Some(Role::Nested) => !state.mode.session_ancestry.is_empty(),
+        }
+    }
+
     #[tracing::instrument(skip_all)]
     pub fn format_string_with_widgets(
         &mut self,
         widgets: &BTreeMap<String, Arc<dyn Widget>>,
         state: &ZellijState,
     ) -> String {
+        if !self.role_matches(state) {
+            return String::new();
+        }
+
         let skip_cache = self.cache_mask & UpdateEventMask::Always as u8 != 0;
 
         if !skip_cache && self.cache_mask & state.cache_mask == 0 && !self.cache.is_empty() {
@@ -238,7 +293,7 @@ impl FormattedPart {
             output = output.replace(match_name, &result);
         }
 
-        let res = self.format_string(&output);
+        let res = self.format_string(&output, state.dim_amount());
         self.cached_content.clone_from(&res);
 
         res
@@ -264,6 +319,7 @@ impl Default for FormattedPart {
             curly_underscore: false,
             dotted_underscore: false,
             dashed_underscore: false,
+            only_when: None,
             content: "".to_owned(),
             cache_mask: 0,
             cached_content: "".to_owned(),
@@ -290,6 +346,45 @@ fn cache_mask_from_content(content: &str) -> u8 {
         output |= event_mask_from_widget_name(widget_key_name);
     }
     output
+}
+
+/// A fully dimmed color sits at this fraction of its own brightness: dimmed
+/// chrome should read as visibly darker, not just the same brightness with
+/// the hue washed out.
+const DIM_BRIGHTNESS: f32 = 0.3;
+
+/// Fades an RGB color toward a dark, desaturated gray by `strength` (`0.0` =
+/// unchanged, `1.0` = fully dimmed). Each channel moves toward
+/// `DIM_BRIGHTNESS` of the color's own perceived luminance, rather than
+/// toward a fixed midpoint or toward the color's own unchanged brightness:
+/// the former reads as a contrast/brightness shift more than a fade for
+/// colors far from that midpoint, and the latter fades out hue without
+/// getting any darker, so dimmed chrome doesn't visually recede the way
+/// core's own dimmed pane chrome does. This blends both at once: a color
+/// fades out its hue while also darkening, ending at a dim neutral gray
+/// rather than just getting flatter. Named ANSI colors and 256-color
+/// palette entries pass through unchanged: they're indices into a
+/// terminal-defined palette, not RGB triples, so there's no well-defined
+/// "dimmed version" of one to compute without also assuming a specific
+/// palette.
+fn dim_color(color: Color, strength: f32) -> Color {
+    match color {
+        Color::Rgb(RgbColor(r, g, b)) => {
+            // ITU-R BT.601 luma weights: the standard "how bright does this
+            // color look" formula used by most grayscale conversions.
+            let luminance = 0.299 * r as f32 + 0.587 * g as f32 + 0.114 * b as f32;
+            let target = luminance * DIM_BRIGHTNESS;
+
+            let blend = |channel: u8| -> u8 {
+                let channel = channel as f32;
+                (channel + (target - channel) * strength)
+                    .round()
+                    .clamp(0.0, 255.0) as u8
+            };
+            Color::Rgb(RgbColor(blend(r), blend(g), blend(b)))
+        }
+        other => other,
+    }
 }
 
 fn hex_to_rgb(s: &str) -> anyhow::Result<Vec<u8>> {
@@ -423,5 +518,74 @@ mod test {
 
         let result = parse_color("$blue", &config);
         assert_eq!(result, None);
+    }
+
+    #[test]
+    fn test_dim_color_blends_rgb_toward_gray() {
+        // Pure red's BT.601 luminance is 0.299*255 = 76.245; the dim target
+        // is 30% of that (~22.9), so full strength converges there on all
+        // three channels: darker than the color's own brightness, not just
+        // desaturated to it.
+        let red = Color::Rgb(RgbColor(255, 0, 0));
+        assert_eq!(dim_color(red, 0.0), red);
+        assert_eq!(dim_color(red, 1.0), Color::Rgb(RgbColor(23, 23, 23)));
+        assert_eq!(dim_color(red, 0.5), Color::Rgb(RgbColor(139, 11, 11)));
+
+        // A color that's already gray has nothing to desaturate, but still
+        // darkens: its luminance equals every channel already, but the dim
+        // target is a fraction of that.
+        let white = Color::Rgb(RgbColor(255, 255, 255));
+        assert_eq!(dim_color(white, 1.0), Color::Rgb(RgbColor(77, 77, 77)));
+    }
+
+    #[test]
+    fn test_dim_color_passes_through_indexed_colors() {
+        let ansi = Color::Ansi(AnsiColor::Red);
+        let ansi256 = Color::Ansi256(Ansi256Color(200));
+        assert_eq!(dim_color(ansi, 0.8), ansi);
+        assert_eq!(dim_color(ansi256, 0.8), ansi256);
+    }
+
+    #[test]
+    fn test_only_when_parses_from_format_string() {
+        let host = FormattedPart::from_format_string("#[only_when=host]foo", &BTreeMap::new());
+        assert_eq!(host.only_when, Some(Role::Host));
+
+        let nested = FormattedPart::from_format_string("#[only_when=nested]foo", &BTreeMap::new());
+        assert_eq!(nested.only_when, Some(Role::Nested));
+
+        let unset = FormattedPart::from_format_string("#[fg=#ff0000]foo", &BTreeMap::new());
+        assert_eq!(unset.only_when, None);
+
+        let invalid = FormattedPart::from_format_string("#[only_when=bogus]foo", &BTreeMap::new());
+        assert_eq!(invalid.only_when, None);
+    }
+
+    #[test]
+    fn test_role_matches() {
+        let host_part = FormattedPart {
+            only_when: Some(Role::Host),
+            ..Default::default()
+        };
+        let nested_part = FormattedPart {
+            only_when: Some(Role::Nested),
+            ..Default::default()
+        };
+        let unconditional_part = FormattedPart::default();
+
+        let mut host_state = ZellijState::default();
+        host_state.mode.session_ancestry = vec![];
+
+        let mut nested_state = ZellijState::default();
+        nested_state.mode.session_ancestry = vec!["outer".to_owned()];
+
+        assert!(host_part.role_matches(&host_state));
+        assert!(!host_part.role_matches(&nested_state));
+
+        assert!(!nested_part.role_matches(&host_state));
+        assert!(nested_part.role_matches(&nested_state));
+
+        assert!(unconditional_part.role_matches(&host_state));
+        assert!(unconditional_part.role_matches(&nested_state));
     }
 }

--- a/src/render.rs
+++ b/src/render.rs
@@ -222,12 +222,18 @@ impl FormattedPart {
     /// Whether this part should render at all given the session's current
     /// host/nested role. A part with no `only_when` attribute always
     /// matches; `session_ancestry` being non-empty means this session is
-    /// nested inside another one.
+    /// nested inside another one. A nested session whose pane currently
+    /// fills its host's entire screen (`host_fullscreen`) is treated as a
+    /// host too: it covers the whole outer session, so it renders the
+    /// same as a standalone one rather than showing nested-only chrome.
     fn role_matches(&self, state: &ZellijState) -> bool {
+        let is_host =
+            state.mode.session_ancestry.is_empty() || state.mode.host_fullscreen == Some(true);
+
         match self.only_when {
             None => true,
-            Some(Role::Host) => state.mode.session_ancestry.is_empty(),
-            Some(Role::Nested) => !state.mode.session_ancestry.is_empty(),
+            Some(Role::Host) => is_host,
+            Some(Role::Nested) => !is_host,
         }
     }
 
@@ -587,5 +593,24 @@ mod test {
 
         assert!(unconditional_part.role_matches(&host_state));
         assert!(unconditional_part.role_matches(&nested_state));
+    }
+
+    #[test]
+    fn test_role_matches_treats_fullscreen_nested_session_as_host() {
+        let host_part = FormattedPart {
+            only_when: Some(Role::Host),
+            ..Default::default()
+        };
+        let nested_part = FormattedPart {
+            only_when: Some(Role::Nested),
+            ..Default::default()
+        };
+
+        let mut fullscreen_nested_state = ZellijState::default();
+        fullscreen_nested_state.mode.session_ancestry = vec!["outer".to_owned()];
+        fullscreen_nested_state.mode.host_fullscreen = Some(true);
+
+        assert!(host_part.role_matches(&fullscreen_nested_state));
+        assert!(!nested_part.role_matches(&fullscreen_nested_state));
     }
 }

--- a/src/widgets/command.rs
+++ b/src/widgets/command.rs
@@ -125,7 +125,7 @@ impl Widget for CommandWidget {
             })
             .fold("".to_owned(), |acc, (f, content)| {
                 if command_config.render_mode == RenderMode::Static {
-                    return format!("{acc}{}", f.format_string(&content));
+                    return format!("{acc}{}", f.format_string(&content, state.dim_amount()));
                 }
 
                 format!("{acc}{}", content)
@@ -133,7 +133,9 @@ impl Widget for CommandWidget {
 
         match command_config.render_mode {
             RenderMode::Static => content,
-            RenderMode::Dynamic => render_dynamic_formatted_content(&content, &self.zj_conf),
+            RenderMode::Dynamic => {
+                render_dynamic_formatted_content(&content, &self.zj_conf, state.dim_amount())
+            }
             RenderMode::Raw => command_result
                 .stdout
                 .strip_suffix('\n')
@@ -167,10 +169,14 @@ impl Widget for CommandWidget {
     }
 }
 
-fn render_dynamic_formatted_content(content: &str, config: &BTreeMap<String, String>) -> String {
+fn render_dynamic_formatted_content(
+    content: &str,
+    config: &BTreeMap<String, String>,
+    dim: f32,
+) -> String {
     formatted_parts_from_string_cached(content, config)
         .iter()
-        .map(|fp| fp.format_string(&fp.content))
+        .map(|fp| fp.format_string(&fp.content, dim))
         .collect::<Vec<String>>()
         .join("")
 }

--- a/src/widgets/datetime.rs
+++ b/src/widgets/datetime.rs
@@ -55,7 +55,7 @@ impl DateTimeWidget {
 }
 
 impl Widget for DateTimeWidget {
-    fn process(&self, _name: &str, _state: &ZellijState) -> String {
+    fn process(&self, _name: &str, state: &ZellijState) -> String {
         let date = Local::now();
 
         let mut tz = Tz::UTC;
@@ -101,7 +101,7 @@ impl Widget for DateTimeWidget {
                 (f, content)
             })
             .fold("".to_owned(), |acc, (f, content)| {
-                format!("{acc}{}", f.format_string(&content))
+                format!("{acc}{}", f.format_string(&content, state.dim_amount()))
             })
     }
 

--- a/src/widgets/mode.rs
+++ b/src/widgets/mode.rs
@@ -135,7 +135,7 @@ impl Widget for ModeWidget {
                 (f, content)
             })
             .fold("".to_owned(), |acc, (f, content)| {
-                format!("{acc}{}", f.format_string(&content))
+                format!("{acc}{}", f.format_string(&content, state.dim_amount()))
             })
     }
 

--- a/src/widgets/notification.rs
+++ b/src/widgets/notification.rs
@@ -68,7 +68,11 @@ impl Widget for NotificationWidget {
                 content = content.replace("{message}", message.body.as_str());
             }
 
-            output = format!("{}{}", output, f.format_string(&content));
+            output = format!(
+                "{}{}",
+                output,
+                f.format_string(&content, state.dim_amount())
+            );
         }
 
         output.to_owned()

--- a/src/widgets/pipe.rs
+++ b/src/widgets/pipe.rs
@@ -72,7 +72,7 @@ impl Widget for PipeWidget {
             })
             .fold("".to_owned(), |acc, (f, content)| {
                 if pipe_config.render_mode == RenderMode::Static {
-                    return format!("{acc}{}", f.format_string(&content));
+                    return format!("{acc}{}", f.format_string(&content, state.dim_amount()));
                 }
 
                 format!("{acc}{}", content)
@@ -80,7 +80,9 @@ impl Widget for PipeWidget {
 
         match pipe_config.render_mode {
             RenderMode::Static => content,
-            RenderMode::Dynamic => render_dynamic_formatted_content(&content, &self.zj_conf),
+            RenderMode::Dynamic => {
+                render_dynamic_formatted_content(&content, &self.zj_conf, state.dim_amount())
+            }
             RenderMode::Raw => pipe_result.to_owned(),
         }
     }
@@ -88,10 +90,14 @@ impl Widget for PipeWidget {
     fn process_click(&self, _name: &str, _state: &crate::config::ZellijState, _pos: usize) {}
 }
 
-fn render_dynamic_formatted_content(content: &str, config: &BTreeMap<String, String>) -> String {
+fn render_dynamic_formatted_content(
+    content: &str,
+    config: &BTreeMap<String, String>,
+    dim: f32,
+) -> String {
     formatted_parts_from_string_cached(content, config)
         .iter()
-        .map(|fp| fp.format_string(&fp.content))
+        .map(|fp| fp.format_string(&fp.content, dim))
         .collect::<Vec<String>>()
         .join("")
 }

--- a/src/widgets/swap_layout.rs
+++ b/src/widgets/swap_layout.rs
@@ -60,7 +60,11 @@ impl Widget for SwapLayoutWidget {
                 content = content.replace("{name}", &name);
             }
 
-            output = format!("{}{}", output, f.format_string(&content));
+            output = format!(
+                "{}{}",
+                output,
+                f.format_string(&content, state.dim_amount())
+            );
         }
 
         output

--- a/src/widgets/tabs.rs
+++ b/src/widgets/tabs.rs
@@ -134,6 +134,7 @@ impl Widget for TabsWidget {
     fn process(&self, _name: &str, state: &ZellijState) -> String {
         let mut output = "".to_owned();
         let mut counter = 0;
+        let dim = state.dim_amount();
 
         let (truncated_start, truncated_end, tabs) =
             get_tab_window(&state.tabs, self.tab_display_count);
@@ -146,12 +147,12 @@ impl Widget for TabsWidget {
                     content = content.replace("{count}", (truncated_start).to_string().as_str());
                 }
 
-                output = format!("{output}{}", f.format_string(&content));
+                output = format!("{output}{}", f.format_string(&content, dim));
             }
         }
 
         for tab in &tabs {
-            let content = self.render_tab(tab, &state.panes, &state.mode);
+            let content = self.render_tab(tab, &state.panes, &state.mode, dim);
             counter += 1;
 
             output = format!("{}{}", output, content);
@@ -159,7 +160,7 @@ impl Widget for TabsWidget {
             if counter < tabs.len()
                 && let Some(sep) = &self.separator
             {
-                output = format!("{}{}", output, sep.format_string(&sep.content));
+                output = format!("{}{}", output, sep.format_string(&sep.content, dim));
             }
         }
 
@@ -171,7 +172,7 @@ impl Widget for TabsWidget {
                     content = content.replace("{count}", (truncated_end).to_string().as_str());
                 }
 
-                output = format!("{output}{}", f.format_string(&content));
+                output = format!("{output}{}", f.format_string(&content, dim));
             }
         }
 
@@ -181,6 +182,7 @@ impl Widget for TabsWidget {
     fn process_click(&self, _name: &str, state: &ZellijState, pos: usize) {
         let mut offset = 0;
         let mut counter = 0;
+        let dim = state.dim_amount();
 
         let (truncated_start, truncated_end, tabs) =
             get_tab_window(&state.tabs, self.tab_display_count);
@@ -201,7 +203,7 @@ impl Widget for TabsWidget {
                     content = content.replace("{count}", (truncated_end).to_string().as_str());
                 }
 
-                offset += console::measure_text_width(&f.format_string(&content));
+                offset += console::measure_text_width(&f.format_string(&content, dim));
 
                 if pos <= offset {
                     switch_tab_to(active_pos.saturating_sub(1) as u32);
@@ -212,13 +214,16 @@ impl Widget for TabsWidget {
         for tab in &tabs {
             counter += 1;
 
-            let mut rendered_content = self.render_tab(tab, &state.panes, &state.mode);
+            let mut rendered_content = self.render_tab(tab, &state.panes, &state.mode, dim);
 
             if counter < tabs.len()
                 && let Some(sep) = &self.separator
             {
-                rendered_content =
-                    format!("{}{}", rendered_content, sep.format_string(&sep.content));
+                rendered_content = format!(
+                    "{}{}",
+                    rendered_content,
+                    sep.format_string(&sep.content, dim)
+                );
             }
 
             let content_len = console::measure_text_width(&rendered_content);
@@ -240,7 +245,7 @@ impl Widget for TabsWidget {
                     content = content.replace("{count}", (truncated_end).to_string().as_str());
                 }
 
-                offset += console::measure_text_width(&f.format_string(&content));
+                offset += console::measure_text_width(&f.format_string(&content, dim));
 
                 if pos <= offset {
                     switch_tab_to(cmp::min(active_pos + 1, state.tabs.len()) as u32);
@@ -296,7 +301,7 @@ impl TabsWidget {
         &self.normal_tab_format
     }
 
-    fn render_tab(&self, tab: &TabInfo, panes: &PaneManifest, mode: &ModeInfo) -> String {
+    fn render_tab(&self, tab: &TabInfo, panes: &PaneManifest, mode: &ModeInfo, dim: f32) -> String {
         let formatters = self.select_format(tab, mode);
         let mut output = "".to_owned();
 
@@ -348,7 +353,7 @@ impl TabsWidget {
 
             content = self.replace_indicators(content, tab, panes);
 
-            output = format!("{}{}", output, f.format_string(&content));
+            output = format!("{}{}", output, f.format_string(&content, dim));
         }
 
         output.to_owned()


### PR DESCRIPTION
Closes #300.

Adds `dim_when_unfocused` / `dim_strength` / `dim_scope` to match core's
chrome dimming for nested sessions, and `only_when=host`/`nested` to gate a
segment to one role. A nested session in fullscreen counts as host, since
that's what's actually on screen.

### Verified

`cargo nextest run --lib --bins`: 32 tests, 11 new, covering dim amount
across session states and color blending for RGB and indexed colors.
